### PR TITLE
Fixed bug in quaternion multiplication

### DIFF
--- a/quat_test.go
+++ b/quat_test.go
@@ -1,3 +1,57 @@
 package mathgl
 
-import ()
+import (
+	"math"
+	"testing"
+)
+
+func TestQuatMulIdentity(t *testing.T) {
+	i1 := Quatd{1.0, Vec3d{0, 0, 0}}
+	i2 := QuatIdentd()
+	i3 := QuatIdentd()
+
+	mul := i2.Mul(i3)
+
+	if !FloatEqual(mul.W, 1.0) {
+		t.Errorf("Multiplication of identities does not yield identity")
+	}
+
+	for i := range mul.V {
+		if mul.V[i] != i1.V[i] {
+			t.Errorf("Multiplication of identities does not yield identity")
+		}
+	}
+}
+
+func TestQuatRotateOnAxis(t *testing.T) {
+	angleDegrees := 30.0
+	axis := Vec3d{1, 0, 0}
+
+	i1 := QuatRotated(angleDegrees, axis)
+
+	rotatedAxis := i1.Rotate(axis)
+
+	for i := range rotatedAxis {
+		if rotatedAxis[i] != axis[i] {
+			t.Errorf("Rotation of axis does not yield identity")
+		}
+	}
+}
+
+func TestQuatRotateOffAxis(t *testing.T) {
+	angleDegrees := 30.0
+	angleRads := angleDegrees * math.Pi / 180.0
+	axis := Vec3d{1, 0, 0}
+
+	i1 := QuatRotated(angleDegrees, axis)
+
+	vector := Vec3d{0, 1, 0}
+	rotatedVector := i1.Rotate(vector)
+	answer := Vec3d{0, math.Cos(angleRads), math.Sin(angleRads)}
+
+	for i := range rotatedVector {
+		if rotatedVector[i] != answer[i] {
+			t.Errorf("Rotation of vector does not yield answer")
+		}
+	}
+}

--- a/quatd.go
+++ b/quatd.go
@@ -42,7 +42,7 @@ func (q1 Quatd) Sub(q2 Quatd) Quatd {
 }
 
 func (q1 Quatd) Mul(q2 Quatd) Quatd {
-	return Quatd{q1.W - q1.V.Dot(q2.V), q1.V.Cross(q2.V).Add(q2.V.Mul(q1.W)).Add(q1.V.Mul(q2.W))}
+	return Quatd{q1.W*q2.W - q1.V.Dot(q2.V), q1.V.Cross(q2.V).Add(q2.V.Mul(q1.W)).Add(q1.V.Mul(q2.W))}
 }
 
 func (q1 Quatd) Scale(c float64) Quatd {

--- a/quatf.go
+++ b/quatf.go
@@ -42,7 +42,7 @@ func (q1 Quatf) Sub(q2 Quatf) Quatf {
 }
 
 func (q1 Quatf) Mul(q2 Quatf) Quatf {
-	return Quatf{q1.W - q1.V.Dot(q2.V), q1.V.Cross(q2.V).Add(q2.V.Mul(q1.W)).Add(q1.V.Mul(q2.W))}
+	return Quatf{q1.W*q2.W - q1.V.Dot(q2.V), q1.V.Cross(q2.V).Add(q2.V.Mul(q1.W)).Add(q1.V.Mul(q2.W))}
 }
 
 func (q1 Quatf) Scale(c float32) Quatf {


### PR DESCRIPTION
I believe the equation for multiplying quaternions in mathgl has a missing term.

See http://en.wikipedia.org/wiki/Quaternion#Quaternions_and_the_geometry_of_R3

I've added tests which identify the bug, and validate the changes I've make in my fork. 

The tests only cover Quatd, although I've tried to make them similar in structure to your existing Vec/Mat tests. I noticed that most of the other tests only cover the `float32` variant. I'd be happy to change that if you have any conventions about the tests.

Thanks for the useful library.
