### PR TITLE
Fixed quaternion to rotation matrix

### DIFF
--- a/quat_test.go
+++ b/quat_test.go
@@ -55,3 +55,25 @@ func TestQuatRotateOffAxis(t *testing.T) {
 		}
 	}
 }
+
+func TestQuatIdentityToMatrix(t *testing.T) {
+	quat := QuatIdentd()
+	matrix := quat.Mat4()
+	answer := Ident4d()
+
+	if !matrix.ApproxEqual(answer) {
+		t.Errorf("Identity quaternion does not yield identity matrix")
+	}
+}
+
+func TestQuatRotationToMatrix(t *testing.T) {
+	angle := 45.0
+	axis := Vec3d{1, 2, 3}.Normalize()
+	quat := QuatRotated(angle, axis)
+	matrix := quat.Mat4()
+	answer := HomogRotate3Dd(angle*math.Pi/180, axis)
+
+	if !matrix.ApproxEqual(answer) {
+		t.Errorf("Rotation quaternion does not yield correct rotation matrix")
+	}
+}

--- a/quatd.go
+++ b/quatd.go
@@ -78,7 +78,7 @@ func (q1 Quatd) Rotate(v Vec3d) Vec3d {
 
 func (q1 Quatd) Mat4() Mat4d {
 	w, x, y, z := q1.W, q1.V[0], q1.V[1], q1.V[2]
-	return Mat4d{1 - 2*y*y - 2*z*z, 2*x*y + 2*w*z, 2*x*z - 2*w*y, 0, 2*x*y - 2*w*z, 1 - 2*x*x - 2*z*z, 2*y*z - 2*w*x, 0, 2*x*z + 2*w*y, 2*y*z + 2*w*x, 1 - 2*x*x - 2*y*y, 0, 0, 0, 0, 1}
+	return Mat4d{1 - 2*y*y - 2*z*z, 2*x*y + 2*w*z, 2*x*z - 2*w*y, 0, 2*x*y - 2*w*z, 1 - 2*x*x - 2*z*z, 2*y*z + 2*w*x, 0, 2*x*z + 2*w*y, 2*y*z - 2*w*x, 1 - 2*x*x - 2*y*y, 0, 0, 0, 0, 1}
 }
 
 func (q1 Quatd) Dot(q2 Quatd) float64 {

--- a/quatf.go
+++ b/quatf.go
@@ -78,7 +78,7 @@ func (q1 Quatf) Rotate(v Vec3f) Vec3f {
 
 func (q1 Quatf) Mat4() Mat4f {
 	w, x, y, z := q1.W, q1.V[0], q1.V[1], q1.V[2]
-	return Mat4f{1 - 2*y*y - 2*z*z, 2*x*y + 2*w*z, 2*x*z - 2*w*y, 0, 2*x*y - 2*w*z, 1 - 2*x*x - 2*z*z, 2*y*z - 2*w*x, 0, 2*x*z + 2*w*y, 2*y*z + 2*w*x, 1 - 2*x*x - 2*y*y, 0, 0, 0, 0, 1}
+	return Mat4f{1 - 2*y*y - 2*z*z, 2*x*y + 2*w*z, 2*x*z - 2*w*y, 0, 2*x*y - 2*w*z, 1 - 2*x*x - 2*z*z, 2*y*z + 2*w*x, 0, 2*x*z + 2*w*y, 2*y*z - 2*w*x, 1 - 2*x*x - 2*y*y, 0, 0, 0, 0, 1}
 }
 
 func (q1 Quatf) Dot(q2 Quatf) float32 {


### PR DESCRIPTION
One more fix, this time when a quaternion is converted to a 4x4 rotation matrix.

Also, its worth noting that other people have forked your libraries and made exactly these changes, over two months ago.

https://github.com/krux02/mathgl/commit/d51e3a47718952db251ee2d5b7499b6393d3aede
