### PR TITLE
Fix Travis gofmt check.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ go:
 script:
  - go test -v ./mgl32
  - go test -v ./mgl64
- - diff <(gofmt -d .) <("") 
+ - diff -u <(echo -n) <(gofmt -d ./)
 
 after_failure: failure
 after_error: failure


### PR DESCRIPTION
Currently, the Travis test passes, but the gofmt diff step is not testing what was intended:

```
$ diff <(gofmt -d .) <("")
/home/travis/build.sh: line 250: : command not found

The command "diff <(gofmt -d .) <("")" exited with 0.
```

This PR fixes it. I've also swapped the the two diff parameters and added -u flag to make the diff (if something isn't gofmt-ed) more readable.
