### PR TITLE
Fix use of deprecated GLSL functions.

### DIFF
--- a/examples/opengl-tutorial/tutorial05/TextureFragmentShader.fragmentshader
+++ b/examples/opengl-tutorial/tutorial05/TextureFragmentShader.fragmentshader
@@ -12,5 +12,5 @@ uniform sampler2D myTextureSampler;
 void main(){
 
 	// Output color = color of the texture at the specified UV
-	color = texture2D( myTextureSampler, UV ).rgb;
+	color = texture( myTextureSampler, UV ).rgb;
 }

--- a/examples/opengl-tutorial/tutorial06/TextureFragmentShader.fragmentshader
+++ b/examples/opengl-tutorial/tutorial06/TextureFragmentShader.fragmentshader
@@ -12,5 +12,5 @@ uniform sampler2D myTextureSampler;
 void main(){
 
 	// Output color = color of the texture at the specified UV
-	color = texture2D( myTextureSampler, UV ).rgb;
+	color = texture( myTextureSampler, UV ).rgb;
 }

--- a/examples/opengl-tutorial/tutorial07/TextureFragmentShader.fragmentshader
+++ b/examples/opengl-tutorial/tutorial07/TextureFragmentShader.fragmentshader
@@ -12,5 +12,5 @@ uniform sampler2D myTextureSampler;
 void main(){
 
 	// Output color = color of the texture at the specified UV
-	color = texture2D( myTextureSampler, UV ).rgb;
+	color = texture( myTextureSampler, UV ).rgb;
 }

--- a/examples/opengl-tutorial/tutorial08/StandardShading.fragmentshader
+++ b/examples/opengl-tutorial/tutorial08/StandardShading.fragmentshader
@@ -21,9 +21,9 @@ void main(){
 	// You probably want to put them as uniforms
 	vec3 LightColor = vec3(1,1,1);
 	float LightPower = 50.0f;
-	
+
 	// Material properties
-	vec3 MaterialDiffuseColor = texture2D( myTextureSampler, UV ).rgb;
+	vec3 MaterialDiffuseColor = texture( myTextureSampler, UV ).rgb;
 	vec3 MaterialAmbientColor = vec3(0.1,0.1,0.1) * MaterialDiffuseColor;
 	vec3 MaterialSpecularColor = vec3(0.3,0.3,0.3);
 
@@ -34,13 +34,13 @@ void main(){
 	vec3 n = normalize( Normal_cameraspace );
 	// Direction of the light (from the fragment to the light)
 	vec3 l = normalize( LightDirection_cameraspace );
-	// Cosine of the angle between the normal and the light direction, 
+	// Cosine of the angle between the normal and the light direction,
 	// clamped above 0
 	//  - light is at the vertical of the triangle -> 1
 	//  - light is perpendicular to the triangle -> 0
 	//  - light is behind the triangle -> 0
 	float cosTheta = clamp( dot( n,l ), 0,1 );
-	
+
 	// Eye vector (towards the camera)
 	vec3 E = normalize(EyeDirection_cameraspace);
 	// Direction in which the triangle reflects the light
@@ -50,8 +50,8 @@ void main(){
 	//  - Looking into the reflection -> 1
 	//  - Looking elsewhere -> < 1
 	float cosAlpha = clamp( dot( E,R ), 0,1 );
-	
-	color = 
+
+	color =
 		// Ambient : simulates indirect lighting
 		MaterialAmbientColor +
 		// Diffuse : "color" of the object

--- a/examples/opengl-tutorial/tutorial09/StandardShading.fragmentshader
+++ b/examples/opengl-tutorial/tutorial09/StandardShading.fragmentshader
@@ -21,9 +21,9 @@ void main(){
 	// You probably want to put them as uniforms
 	vec3 LightColor = vec3(1,1,1);
 	float LightPower = 50.0f;
-	
+
 	// Material properties
-	vec3 MaterialDiffuseColor = texture2D( myTextureSampler, UV ).rgb;
+	vec3 MaterialDiffuseColor = texture( myTextureSampler, UV ).rgb;
 	vec3 MaterialAmbientColor = vec3(0.1,0.1,0.1) * MaterialDiffuseColor;
 	vec3 MaterialSpecularColor = vec3(0.3,0.3,0.3);
 
@@ -34,13 +34,13 @@ void main(){
 	vec3 n = normalize( Normal_cameraspace );
 	// Direction of the light (from the fragment to the light)
 	vec3 l = normalize( LightDirection_cameraspace );
-	// Cosine of the angle between the normal and the light direction, 
+	// Cosine of the angle between the normal and the light direction,
 	// clamped above 0
 	//  - light is at the vertical of the triangle -> 1
 	//  - light is perpendicular to the triangle -> 0
 	//  - light is behind the triangle -> 0
 	float cosTheta = clamp( dot( n,l ), 0,1 );
-	
+
 	// Eye vector (towards the camera)
 	vec3 E = normalize(EyeDirection_cameraspace);
 	// Direction in which the triangle reflects the light
@@ -50,8 +50,8 @@ void main(){
 	//  - Looking into the reflection -> 1
 	//  - Looking elsewhere -> < 1
 	float cosAlpha = clamp( dot( E,R ), 0,1 );
-	
-	color = 
+
+	color =
 		// Ambient : simulates indirect lighting
 		MaterialAmbientColor +
 		// Diffuse : "color" of the object


### PR DESCRIPTION
As far as I understand, `texture2D` has been deprecated as of OpenGL 3.0 and `texture` should be used instead.

Fixes the following issue:

```
$ ./tutorial05 
2014/06/14 16:17:40 vert shader compilation status: 0
2014/06/14 16:17:40 Info log: ERROR: 0:15: Call to undeclared function 'texture2D'
2014/06/14 16:17:40 Problem creating shader?
panic: Problem creating shader?

goroutine 1 [running]:
runtime.panic(0x40ff700, 0xc21000a2f0)
    /usr/local/go/src/pkg/runtime/panic.c:266 +0xb6
log.Panic(0x44d65b8, 0x1, 0x1)
    /usr/local/go/src/pkg/log/log.go:307 +0xac
github.com/go-gl/glh.MakeShader(0x8b30, 0xc21001f140, 0x13f, 0x200000001)
    /Users/Dmitri/Dropbox/Work/2013/GoLanding/src/github.com/go-gl/glh/shader.go:56 +0x377
github.com/go-gl/glh.Shader.Compile(0x8b30, 0xc21001f140, 0x13f, 0x2)
    /Users/Dmitri/Dropbox/Work/2013/GoLanding/src/github.com/go-gl/glh/shader.go:19 +0x36
github.com/go-gl/glh.NewProgram(0x44d6858, 0x2, 0x2, 0xc21001f140)
    /Users/Dmitri/Dropbox/Work/2013/GoLanding/src/github.com/go-gl/glh/shader.go:25 +0xc0
github.com/go-gl/mathgl/examples/opengl-tutorial/helper.MakeProgram(0x4189950, 0x22, 0x41898d0, 0x24, 0x0)
    /Users/Dmitri/Dropbox/Work/2013/GoLand/src/github.com/go-gl/mathgl/examples/opengl-tutorial/helper/helper.go:31 +0x24c
main.main()
    /Users/Dmitri/Dropbox/Work/2013/GoLand/src/github.com/go-gl/mathgl/examples/opengl-tutorial/tutorial05/main.go:54 +0x3e7

goroutine 3 [syscall]:
runtime.goexit()
    /usr/local/go/src/pkg/runtime/proc.c:1394
```

I am less confident about this change, so please review.
