### PR TITLE
Added NxM matrix and N-length vector

### DIFF
--- a/mgl32/doc.go
+++ b/mgl32/doc.go
@@ -14,5 +14,9 @@ instead, as all basic functions are documented.
 
 This package is written in Column Major Order to make it easier with OpenGL. This means for uniform blocks you can use the default ordering, and when you call
 pass-in functions you can leave the "transpose" argument as false.
+
+The package now contains variable sized vectors and matrices. Using these is discouraged. They exist for corner cases where you need "small" matrices that are still
+bigger than 4x4. An example may be a Jacobean used for inverse kinematics. Things like computer vision or general linear algebra are best left to packages
+more directly suited for that task -- OpenCV, BLAS, LAPACK, numpy, gonum (if you want to stay in Go), and so on.
 */
 package mgl32

--- a/mgl32/matmn.go
+++ b/mgl32/matmn.go
@@ -1,0 +1,481 @@
+package mgl32
+
+import (
+	"math"
+)
+
+// An arbitrary mxn matrix backed by a slice of floats.
+//
+// This is emphatically not recommended for hardcore n-dimensional
+// linear algebra. For that purpose I recommend github.com/gonum/matrix or
+// well-tested C libraries such as BLAS or LAPACK.
+//
+// This is meant to complement future algorithms that may require matrices larger than
+// 4x4, but still relatively small (e.g. Jacobeans for inverse kinematics).
+//
+// It makes use of the same memory sync.Pool set that VecN does, with the same sizing rules.
+//
+// MatMN will always check if the receiver is nil on any method. Meaning MathMN(nil).Add(dst,m2)
+// should always work. Except for the Reshape function, the semantics of this is to "propogate" nils
+// forward, so if an invalid operation occurs in a long chain of matrix operations, the overall result will be nil.
+type MatMxN struct {
+	m, n int
+	dat  []float32
+}
+
+// Creates a matrix backed by a new slice of size m*n
+func NewMatrix(m, n int) (mat *MatMxN) {
+	return &MatMxN{m: m, n: n, dat: grabFromPool(m * n)}
+}
+
+// Returns a matrix with data specified by the data in src
+//
+// For instance, to create a 3x3 MatMN from a Mat3
+//
+//    m1 := mgl32.Rotate3DX(3.14159)
+//    mat := mgl32.NewBackedMatrix(m1[:],3,3)
+//
+// will create an MN matrix matching the data in the original
+// rotation matrix. This matrix is NOT backed by the initial slice;
+// it's a copy of the data
+//
+// If m*n > cap(src), this function will panic.
+func NewMatrixFromData(src []float32, m, n int) *MatMxN {
+	internal := grabFromPool(m * n)
+	copy(internal, src[:m*n])
+
+	return &MatMxN{m: m, n: n, dat: internal}
+}
+
+// Copies src into dst. This Reshapes dst
+// to the same size as src.
+//
+// If dst or src is nil, this is a no-op
+func CopyMatMN(dst, src *MatMxN) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.Reshape(src.m, src.n)
+	copy(dst.dat, src.dat)
+}
+
+// Stores the NxN identity matrix in dst, reallocating as necessary.
+func IdentN(dst *MatMxN, n int) *MatMxN {
+	dst = dst.Reshape(n, n)
+
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				dst.Set(i, j, 1)
+			} else {
+				dst.Set(i, j, 0)
+			}
+		}
+	}
+
+	return dst
+}
+
+// Creates an NxN diagonal matrix seeded by the diagonal vector
+// diag. Meaning: for all entries, where i==j, dst.At(i,j) = diag[i]. Otherwise
+// dst.At(i,j) = 0
+//
+// This reshapes dst to the correct size, returning/grabbing from the memory pool as necessary.
+func DiagN(dst *MatMxN, diag *VecN) *MatMxN {
+	dst = dst.Reshape(len(diag.vec), len(diag.vec))
+	n := len(diag.vec)
+
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				dst.Set(i, j, diag.vec[i])
+			} else {
+				dst.Set(i, j, 0)
+			}
+		}
+	}
+
+	return dst
+}
+
+// Reshapes the matrix to m by n and zeroes out all
+// elements.
+func (mat *MatMxN) Zero(m, n int) {
+	if mat == nil {
+		return
+	}
+
+	mat.Reshape(m, n)
+	for i := range mat.dat {
+		mat.dat[i] = 0
+	}
+}
+
+// Returns the underlying matrix slice to the memory pool
+func (mat *MatMxN) destroy() {
+	if mat == nil {
+		return
+	}
+
+	if mat.dat != nil {
+		returnToPool(mat.dat)
+	}
+	mat.m, mat.n = 0, 0
+	mat.dat = nil
+}
+
+// Reshapes the matrix to the desired dimensions.
+// If the overall size of the new matrix (m*n) is bigger
+// than the current size, the underlying slice will
+// be grown, sending the current slice to the memory pool
+// and grabbing a bigger one if necessary
+//
+// If the caller is a nil pointer, the return value will be a new
+// matrix, as if NewMatrix(m,n) had been called. Otherwise it's
+// simply the caller.
+func (mat *MatMxN) Reshape(m, n int) *MatMxN {
+	if mat == nil {
+		return NewMatrix(m, n)
+	}
+
+	if m*n <= cap(mat.dat) {
+		if mat.dat != nil {
+			mat.dat = mat.dat[:m*n]
+		} else {
+			mat.dat = []float32{}
+		}
+		mat.m, mat.n = m, n
+		return mat
+	}
+
+	if mat.dat != nil {
+		returnToPool(mat.dat)
+	}
+	mat.dat = grabFromPool(m * n)
+	mat.m, mat.n = m, n
+
+	return mat
+}
+
+// Infers an MxN matrix from a constant matrix from this package. For instance,
+// a Mat2x3 inferred with this function will work just like NewMatrixFromData(m[:],2,3)
+// where m is the Mat2x3. This uses a type switch.
+//
+// I personally recommend using NewMatrixFromData, because it avoids a potentially costly type switch.
+// However, this is also more robust and less error prone if you change the size of your matrix somewhere.
+//
+// If the value passed in is not recognized, it returns an InferMatrixError.
+func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
+	switch raw := m.(type) {
+	case Mat2:
+		return NewMatrixFromData(raw[:], 2, 2), nil
+	case Mat2x3:
+		return NewMatrixFromData(raw[:], 2, 3), nil
+	case Mat2x4:
+		return NewMatrixFromData(raw[:], 2, 4), nil
+	case Mat3:
+		return NewMatrixFromData(raw[:], 3, 3), nil
+	case Mat3x2:
+		return NewMatrixFromData(raw[:], 3, 2), nil
+	case Mat3x4:
+		return NewMatrixFromData(raw[:], 3, 4), nil
+	case Mat4:
+		return NewMatrixFromData(raw[:], 4, 4), nil
+	case Mat4x2:
+		return NewMatrixFromData(raw[:], 4, 2), nil
+	case Mat4x3:
+		return NewMatrixFromData(raw[:], 4, 3), nil
+	default:
+		return nil, InferMatrixError{}
+	}
+}
+
+// Returns the trace of a square matrix (sum of all diagonal elements). If the matrix
+// is nil, or not square, the result will be NaN.
+func (mat *MatMxN) Trace() float32 {
+	if mat == nil || mat.m != mat.n {
+		return float32(math.NaN())
+	}
+
+	var out float32
+	for i := 0; i < mat.m; i++ {
+		out += mat.At(i, i)
+	}
+
+	return out
+}
+
+// Takes the transpose of mat and puts it in dst.
+//
+// If dst is not of the correct dimensions, it will be Reshaped,
+// if dst and mat are the same, a temporary matrix of the correct size will
+// be allocated; these resources will be released via the memory pool if
+// it is registered. This should be improved in the future.
+func (mat *MatMxN) Transpose(dst *MatMxN) (t *MatMxN) {
+	if mat == nil {
+		return nil
+	}
+
+	if dst == mat {
+		dst = NewMatrix(mat.n, mat.m)
+
+		// Copy data to correct matrix,
+		// delete temporary buffer,
+		// and set the return value to the
+		// correct one
+		defer func() {
+			copy(mat.dat, dst.dat)
+
+			mat.m, mat.n = mat.n, mat.m
+
+			dst.destroy()
+			t = mat
+		}()
+
+		return mat
+	} else {
+		dst = dst.Reshape(mat.n, mat.m)
+	}
+
+	for r := 0; r < mat.m; r++ {
+		for c := 0; c < mat.n; c++ {
+			dst.dat[r*dst.m+c] = mat.dat[c*mat.m+r]
+		}
+	}
+
+	return dst
+}
+
+// Returns the raw slice backing this matrix
+func (mat *MatMxN) Raw() []float32 {
+	if mat == nil {
+		return nil
+	}
+
+	return mat.dat
+}
+
+// Returns the number of rows in this matrix
+func (mat *MatMxN) NumRows() int {
+	return mat.m
+}
+
+// Returns the number of columns in this matrix
+func (mat *MatMxN) NumCols() int {
+	return mat.n
+}
+
+// Returns the number of rows and columns in this matrix
+// as a single operation
+func (mat *MatMxN) NumRowCols() (rows, cols int) {
+	return mat.m, mat.n
+}
+
+// Returns the element at the given row and column.
+// This is garbage in/garbage out and does no bounds
+// checking. If the computation happens to lead to an invalid
+// element, it will be returned; or it may panic.
+func (mat *MatMxN) At(row, col int) float32 {
+	return mat.dat[col*mat.m+row]
+}
+
+// Sets the element at the given row and column.
+// This is garbage in/garbage out and does no bounds
+// checking. If the computation happens to lead to an invalid
+// element, it will be set; or it may panic.
+func (mat *MatMxN) Set(row, col int, val float32) {
+	mat.dat[col*mat.m+row] = val
+}
+
+func (mat *MatMxN) Add(dst *MatMxN, addend *MatMxN) *MatMxN {
+	if mat == nil || addend == nil || mat.m != addend.m || mat.n != addend.n {
+		return nil
+	}
+
+	dst = dst.Reshape(mat.m, mat.n)
+
+	// No need to care about rows and columns
+	// since it's element-wise anyway
+	for i, el := range mat.dat {
+		dst.dat[i] = el + addend.dat[i]
+	}
+
+	return dst
+}
+
+func (mat *MatMxN) Sub(dst *MatMxN, minuend *MatMxN) *MatMxN {
+	if mat == nil || minuend == nil || mat.m != minuend.m || mat.n != minuend.n {
+		return nil
+	}
+
+	dst = dst.Reshape(mat.m, mat.n)
+
+	// No need to care about rows and columns
+	// since it's element-wise anyway
+	for i, el := range mat.dat {
+		dst.dat[i] = el - minuend.dat[i]
+	}
+
+	return dst
+}
+
+// Performs matrix multiplication on MxN matrix mat and NxO matrix mul, storing the result in dst.
+// This returns dst, or nil if the operation is not able to be performed.
+//
+// If mat == dst, or mul == dst a temporary matrix will be used.
+//
+// This uses the naive algorithm (though on smaller matrices,
+// this can actually be faster; about len(mat)+len(mul) < ~100)
+func (mat *MatMxN) MulMxN(dst *MatMxN, mul *MatMxN) *MatMxN {
+	if mat == nil || mul == nil || mat.n != mul.m {
+		return nil
+	}
+
+	if dst == mul {
+		mul = &MatMxN{m: mul.m, n: mul.n, dat: make([]float32, mul.m*mul.n)}
+		copy(mul.dat, dst.dat)
+
+		// If mul==dst==mul, we need to change
+		// mat too or we have a bug
+		if mul == dst {
+			mat = mul
+		}
+
+		defer mul.destroy()
+	} else if dst == mat {
+		mat = &MatMxN{m: mat.m, n: mat.n, dat: make([]float32, mat.m*mat.n)}
+		copy(mat.dat, dst.dat)
+
+		defer mat.destroy()
+	}
+
+	dst = dst.Reshape(mat.m, mul.n)
+	for r1 := 0; r1 < mat.m; r1++ {
+		for c2 := 0; c2 < mul.n; c2++ {
+
+			dst.dat[c2*mat.m+r1] = 0
+			for i := 0; i < mat.n; i++ {
+				dst.dat[c2*mat.m+r1] += mat.dat[i*mat.m+r1] * mul.dat[c2*mul.m+i]
+			}
+
+		}
+	}
+
+	return dst
+}
+
+// Performs a scalar multiplication between mat and some constant c,
+// storing the result in dst. Mat and dst can be equal. If dst is not the
+// correct size, a Reshape will occur.
+func (mat *MatMxN) Mul(dst *MatMxN, c float32) *MatMxN {
+	if mat == nil {
+		return nil
+	}
+
+	dst = dst.Reshape(mat.m, mat.n)
+
+	for i, el := range mat.dat {
+		dst.dat[i] = el * c
+	}
+
+	return dst
+}
+
+// Multiplies the matrix by a vector of size n. If mat or v is
+// nil, this returns nil. If the number of columns in mat does not match
+// the Size of v, this also returns nil.
+//
+// Dst will be resized if it's not big enough. If dst == v; a temporary
+// vector will be allocated and returned via the realloc callback when complete.
+func (mat *MatMxN) MulNx1(dst, v *VecN) *VecN {
+	if mat == nil || v == nil || mat.n != len(v.vec) {
+		return nil
+	}
+	if dst == v {
+		v = &VecN{make([]float32, len(v.vec))}
+		copy(v.vec, dst.vec)
+
+		defer v.destroy()
+	}
+
+	dst = dst.Resize(len(v.vec))
+
+	for r := range v.vec {
+		dst.vec[r] = 0
+
+		for c := 0; c < mat.n; c++ {
+			dst.vec[r] += mat.At(r, c) * v.vec[c]
+		}
+	}
+
+	return dst
+}
+
+func (mat *MatMxN) ApproxEqual(m2 *MatMxN) bool {
+	if mat == m2 {
+		return true
+	}
+	if mat.m != m2.m || mat.n != m2.n {
+		return false
+	}
+
+	for i, el := range mat.dat {
+		if !FloatEqual(el, m2.dat[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (mat *MatMxN) ApproxEqualThreshold(m2 *MatMxN, epsilon float32) bool {
+	if mat == m2 {
+		return true
+	}
+	if mat.m != m2.m || mat.n != m2.n {
+		return false
+	}
+
+	for i, el := range mat.dat {
+		if !FloatEqualThreshold(el, m2.dat[i], epsilon) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (mat *MatMxN) ApproxEqualFunc(m2 *MatMxN, comp func(float32, float32) bool) bool {
+	if mat == m2 {
+		return true
+	}
+	if mat.m != m2.m || mat.n != m2.n {
+		return false
+	}
+
+	for i, el := range mat.dat {
+		if !comp(el, m2.dat[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type InferMatrixError struct{}
+
+func (me InferMatrixError) Error() string {
+	return "could not infer matrix. Make sure you're using a constant matrix such as Mat3 from within the same package (meaning: mgl32.MatMxN can't handle a mgl64.Mat2x3)."
+}
+
+type RectangularMatrixError struct{}
+
+func (mse RectangularMatrixError) Error() string {
+	return "the matrix was the wrong shape, needed a square matrix."
+}
+
+type NilMatrixError struct{}
+
+func (me NilMatrixError) Error() string {
+	return "the matrix is nil"
+}

--- a/mgl32/matmn_test.go
+++ b/mgl32/matmn_test.go
@@ -1,0 +1,167 @@
+package mgl32
+
+import (
+	"testing"
+)
+
+func TestMxNTransposeWide(t *testing.T) {
+	m := Mat2x3FromCols(
+		Vec2{1, 2},
+		Vec2{3, 4},
+		Vec2{5, 6},
+	)
+
+	mn := NewMatrixFromData(m[:], 2, 3)
+
+	transpose := m.Transpose()
+
+	transposeMN := mn.Transpose(nil)
+
+	correct := NewMatrixFromData(transpose[:], 3, 2)
+
+	if !correct.ApproxEqualThreshold(transposeMN, 1e-4) {
+		t.Errorf("Transpose gives incorrect result; got: %v, expected: %v", transposeMN, correct)
+	}
+}
+
+func TestMxNTransposeTall(t *testing.T) {
+	m := Mat3x2FromCols(
+		Vec3{1, 2, 3},
+		Vec3{4, 5, 6},
+	)
+
+	mn := NewMatrixFromData(m[:], 3, 2)
+
+	transpose := m.Transpose()
+
+	transposeMN := mn.Transpose(nil)
+
+	correct := NewMatrixFromData(transpose[:], 2, 3)
+
+	if !correct.ApproxEqualThreshold(transposeMN, 1e-4) {
+		t.Errorf("Transpose gives incorrect result; got: %v, expected: %v", transposeMN, correct)
+	}
+}
+
+func TestMxNTransposeSquare(t *testing.T) {
+	m := Mat3FromCols(
+		Vec3{1, 2, 3},
+		Vec3{4, 5, 6},
+		Vec3{7, 8, 9},
+	)
+
+	mn := NewMatrixFromData(m[:], 3, 3)
+
+	transpose := m.Transpose()
+
+	transposeMN := mn.Transpose(nil)
+
+	correct := NewMatrixFromData(transpose[:], 3, 3)
+
+	if !correct.ApproxEqualThreshold(transposeMN, 1e-4) {
+		t.Errorf("Transpose gives incorrect result; got: %v, expected: %v", transposeMN, correct)
+	}
+}
+
+func TestMxNAtSet(t *testing.T) {
+	m := Mat3{1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+	mn := NewMatrixFromData(m[:], 3, 3)
+
+	v := mn.At(0, 2)
+
+	if !FloatEqualThreshold(v, 7, 1e-4) {
+		t.Errorf("Incorrect value gotten by At: %v, expected %v", v, 7)
+	}
+
+	mn.Set(0, 2, 9001)
+
+	v = mn.At(0, 2)
+
+	if !FloatEqualThreshold(v, 9001, 1e-4) {
+		t.Errorf("Incorrect value set by Set: %v, expected %v", v, 9001)
+	}
+
+	correct := Mat3{1, 2, 3, 4, 5, 6, 9001, 8, 9}
+	correctMN := NewMatrixFromData(correct[:], 3, 3)
+
+	if !correctMN.ApproxEqualThreshold(mn, 1e-4) {
+		t.Errorf("Set matrix does not equal correct matrix. Got: %v, expected: %v", mn, correctMN)
+	}
+}
+
+func TestMxNMulMxN(t *testing.T) {
+	m := Ident4()
+	r := HomogRotate3DX(DegToRad(45))
+	tr := Translate3D(1, 0, 0)
+	s := Scale3D(2, 2, 2)
+
+	correct := tr.Mul4(r.Mul4(s.Mul4(m))) // tr*r*s
+	correctMN := NewMatrixFromData(correct[:], 4, 4)
+
+	mn := NewMatrixFromData(m[:], 4, 4)
+	rmn := NewMatrixFromData(r[:], 4, 4)
+	trmn := NewMatrixFromData(tr[:], 4, 4)
+	smn := NewMatrixFromData(s[:], 4, 4)
+
+	result := trmn.MulMxN(nil, rmn.MulMxN(nil, smn.MulMxN(nil, mn)))
+
+	if !result.ApproxEqualThreshold(correctMN, 1e-4) {
+		t.Errorf("Multiplication of MxN matrix and 4x4 matrix not the same. Got: %v expected: %v", result, correctMN)
+	}
+}
+
+func TestMxNMulMxNErrorHandling(t *testing.T) {
+	mn := NewMatrix(4, 12)
+	mn2 := NewMatrix(9, 3)
+
+	result := mn2.MulMxN(nil, mn)
+
+	if result != nil {
+		t.Errorf("Nil not returned for bad matrix multiplication, got %v instead", result)
+	}
+}
+
+func TestMxNMul(t *testing.T) {
+	m := Mat3{2, 4, 6, 1, 9, 12, 7, 4, 3}
+	mn := NewMatrixFromData(m[:], 3, 3)
+
+	correct := m.Mul(15)
+	correctMN := NewMatrixFromData(correct[:], 3, 3)
+
+	result := mn.Mul(nil, 15)
+
+	if !correctMN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("Scaling a matrix produces weird results got: %v, expected: %v", result, correct)
+	}
+}
+
+func TestMxNMulNx1(t *testing.T) {
+	m := Ident4()
+	r := HomogRotate3DX(DegToRad(45))
+	tr := Translate3D(1, 0, 0)
+	s := Scale3D(2, 2, 2)
+
+	model := tr.Mul4(r.Mul4(s.Mul4(m)))
+
+	v := Vec4{5, 5, 5, 1}
+	correct := model.Mul4x1(v)
+	correctn := NewVecNFromData(correct[:])
+
+	modelMN := NewMatrixFromData(model[:], 4, 4)
+	vn := NewVecNFromData(v[:])
+
+	result := modelMN.MulNx1(nil, vn)
+
+	if !correctn.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("Multiplying N-dim vector and MxN matrix produces bad result. Got: %v, expected: %v", result, correct)
+	}
+}
+
+func TestMxNTrace(t *testing.T) {
+	m := DiagN(nil, NewVecNFromData([]float32{1, 2, 3, 4, 5}))
+
+	if !FloatEqualThreshold(m.Trace(), 15, 1e-4) {
+		t.Errorf("MatMxN's trace of a diagonal with 1,2,3,4,5 is not 15. Got: %v", m.Trace())
+	}
+}

--- a/mgl32/mempool.go
+++ b/mgl32/mempool.go
@@ -1,0 +1,111 @@
+package mgl32
+
+import (
+	"sync"
+)
+
+var (
+	slicePools []*sync.Pool
+	listLock   sync.RWMutex
+)
+
+// Returns the given memory pool. If the pool doesn't exist, it will
+// create all pools up to element i. The number "i" corresponds to "p"
+// in most other comments. That is, it's Ceil(log_2(whatever)). So i=0
+// means you'll get the pool for slices of size 1, i=1 for size 2, i=2 for size 4,
+// and so on.
+//
+// This is concurrency safe and uses an RWMutex to protect the list expansion.
+func getPool(i int) *sync.Pool {
+	listLock.RLock()
+	if i >= len(slicePools) {
+
+		// Promote to a write lock because we now
+		// need to mutate the pool
+		listLock.RUnlock()
+		listLock.Lock()
+		defer listLock.Unlock()
+
+		for n := i - len(slicePools); n >= 0; n-- {
+			newFunc := genPoolNew(1 << uint(len(slicePools)))
+			slicePools = append(slicePools, &sync.Pool{New: newFunc})
+		}
+	} else {
+		defer listLock.RUnlock()
+	}
+
+	return slicePools[i]
+}
+
+func genPoolNew(i int) func() interface{} {
+	return func() interface{} {
+		return make([]float32, 0, i)
+	}
+}
+
+// Grabs a slice from the memory pool, such that its cap
+// is 2^p where p is Ceil(log_2(size)). It will be downsliced
+// such that the cap is size.
+func grabFromPool(size int) []float32 {
+	pool, exact := binLog(size)
+
+	// Tried to grab something of size
+	// zero or less
+	if pool == -1 {
+		return nil
+	}
+
+	// If the log is not exact, we
+	// need to "overallocate" so we have
+	// log+1
+	if !exact {
+		pool++
+	}
+
+	slice := getPool(pool).Get().([]float32)
+	slice = slice[:size]
+	return slice
+}
+
+// Returns a slice to the appropriate pool. If the slice does not have a cap that's precisely
+// a power of 2, this will panic.
+func returnToPool(slice []float32) {
+	if cap(slice) == 0 {
+		return
+	}
+
+	pool, exact := binLog(cap(slice))
+
+	if !exact {
+		panic("attempt to pool slice with non-exact cap. If you're a user, please file an issue with github.com/go-gl/mathgl about this bug. This should never happen.")
+	}
+
+	getPool(pool).Put(slice)
+}
+
+// This returns the integer base 2 log of the value
+// and whether the log is exact or rounded down.
+//
+// This is only for positive integers.
+//
+// There are faster ways to do this, I'm open to suggestions. Most rely on knowing system endianness
+// which Go makes hard to do. I'm hesistant to use float conversions and the math package because of off-by-one errors.
+func binLog(val int) (int, bool) {
+	if val <= 0 {
+		return -1, false
+	}
+
+	exact := true
+	l := 0
+	for ; val > 1; val = val >> 1 {
+		// If the current lsb is 1 and the number
+		// is not equal to 1, this is not an exact
+		// log, but rather a rounding of it
+		if val&1 != 0 {
+			exact = false
+		}
+		l++
+	}
+
+	return l, exact
+}

--- a/mgl32/mempool_test.go
+++ b/mgl32/mempool_test.go
@@ -1,0 +1,71 @@
+package mgl32
+
+import (
+	"testing"
+)
+
+func TestBinLog(t *testing.T) {
+	tests := []struct {
+		in int
+
+		// out
+		val   int
+		exact bool
+	}{
+		{-256, -1, false},
+		{0, -1, false},
+		{1, 0, true},
+		{2, 1, true},
+		{3, 1, false},
+		{32, 5, true},
+		{37, 5, false},
+	}
+
+	for _, test := range tests {
+		outV, outE := binLog(test.in)
+		if outV != test.val || outE != test.exact {
+			t.Errorf("binLog gives incorrect result for input %v. Got: (%v,%v); Expected: (%v,%v)", test.in, outV, outE, test.val, test.exact)
+		}
+	}
+}
+
+func TestGetPool(t *testing.T) {
+	slicePools = nil
+	pool := getPool(3)
+
+	if len(slicePools) != 4 || pool == nil {
+		t.Errorf("Couldn't get pool. Size of slice %v (should be 4)", len(slicePools))
+	}
+
+	slice, ok := pool.Get().([]float32)
+	if slice == nil || !ok || cap(slice) != 1<<3 {
+		t.Errorf("Slice from pool either not allocated, not ok, or of wrong cap. Got slice: %v, ok: %v, cap: %v", slice, ok, cap(slice))
+	}
+}
+
+func TestGrabFromPool(t *testing.T) {
+	slicePools = nil
+	slice := grabFromPool(17)
+
+	if slice == nil || len(slice) != 17 || cap(slice) != 32 {
+		t.Errorf("Got bad, ill sized, or badly capped slice from grabFromPool. Slice: %v, len: %v, cap: %v", slice, len(slice), cap(slice))
+	}
+}
+
+func BenchmarkBinLogReasonable(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _ = binLog(100)
+	}
+}
+
+func BenchmarkBinLogBig(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _ = binLog(1<<30 + 1)
+	}
+}
+
+func BenchmarkBinLogSmall(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _ = binLog(10)
+	}
+}

--- a/mgl32/vecn.go
+++ b/mgl32/vecn.go
@@ -1,0 +1,323 @@
+package mgl32
+
+import (
+	"math"
+)
+
+// A vector of N elements backed by a slice
+//
+// As with MatMxN, this is not for hardcore linear algebra with large dimensions. Use github.com/gonum/matrix
+// or something like BLAS/LAPACK for that. This is for corner cases in 3D math where you require
+// something a little bigger that 4D, but still relatively small.
+//
+// This VecN uses several sync.Pool objects as a memory pool. The rule is that for any sized vector, the backing slice
+// has CAPACITY (not length) of 2^p where p is Ceil(log_2(N)) -- or in other words, rounding up the base-2
+// log of the size of the vector. E.G. a VecN of size 17 will have a backing slice of Cap 32.
+type VecN struct {
+	vec []float32
+}
+
+// Creates a new vector with a backing slice filled with the contents
+// of initial. It is NOT backed by initial, but rather a slice with cap
+// 2^p where p is Ceil(log_2(len(initial))), with the data from initial copied into
+// it.
+func NewVecNFromData(initial []float32) *VecN {
+	if initial == nil {
+		return &VecN{}
+	}
+	internal := grabFromPool(len(initial))
+	copy(internal, initial)
+	return &VecN{vec: internal}
+}
+
+// Creates a new vector with a backing slice of
+// 2^p where p = Ceil(log_2(n))
+func NewVecN(n int) *VecN {
+	return &VecN{vec: grabFromPool(n)}
+}
+
+// Returns the raw slice backing the VecN
+//
+// This may be sent back to the memory pool at any time
+// and you aren't advised to rely on this value
+func (vn VecN) Raw() []float32 {
+	return vn.vec
+}
+
+// Gets the element at index i from the vector.
+// This does not bounds check, and will panic if i is
+// out of range.
+func (vn VecN) Get(i int) float32 {
+	return vn.vec[i]
+}
+
+// Sends the allocated memory through the callback if it exists
+func (vn *VecN) destroy() {
+	if vn == nil || vn.vec == nil {
+		return
+	}
+
+	returnToPool(vn.vec)
+	vn.vec = nil
+}
+
+// Resizes the underlying slice to the desired amount, reallocating or retrieving from the pool
+// if necessary. This does not zero any values.
+//
+// If the caller is a nil pointer, this returns a value as if NewVecN(n) had been called,
+// otherwise it simply returns the caller.
+func (vn *VecN) Resize(n int) *VecN {
+	if vn == nil {
+		return NewVecN(n)
+	}
+
+	if n <= cap(vn.vec) {
+		if vn.vec != nil {
+			vn.vec = vn.vec[:n]
+		} else {
+			vn.vec = []float32{}
+		}
+		return vn
+	}
+
+	if vn.vec != nil {
+		returnToPool(vn.vec)
+	}
+	vn.vec = grabFromPool(n)
+	return vn
+}
+
+// Sets the vector's backing slice to the given
+// new one.
+func (vn *VecN) SetBackingSlice(newSlice []float32) {
+	vn.vec = newSlice
+}
+
+// Return the len of the vector's underlying slice.
+// This is not titled Len because it conflicts the package's
+// convention of calling the Norm the Len.
+func (vn *VecN) Size() int {
+	return len(vn.vec)
+}
+
+// Returns the cap of the vector's underlying slice.
+func (vn *VecN) Cap() int {
+	return cap(vn.vec)
+}
+
+// Sets the vector's size to n and zeroes out the vector.
+// If n is bigger than the vector's size, it will realloc.
+func (vn *VecN) Zero(n int) {
+	vn.Resize(n)
+	for i := range vn.vec {
+		vn.vec[i] = 0
+	}
+}
+
+// Adds vn and addend, storing the result in dst.
+// If dst does not have sufficient size it will be resized
+// Dst may be one of the other arguments. If dst is nil, it will be allocated.
+// The value returned is dst, for easier method chaining
+//
+// If vn and addend are not the same size, this function will add min(vn.Size(), addend.Size())
+// elements.
+func (vn *VecN) Add(dst *VecN, minuend *VecN) *VecN {
+	if vn == nil || minuend == nil {
+		return nil
+	}
+	size := intMin(len(vn.vec), len(minuend.vec))
+	dst = dst.Resize(size)
+
+	for i := 0; i < size; i++ {
+		dst.vec[i] = vn.vec[i] + minuend.vec[i]
+	}
+
+	return dst
+}
+
+// Subtracts addend from vn, storing the result in dst.
+// If dst does not have sufficient size it will be resized
+// Dst may be one of the other arguments. If dst is nil, it will be allocated.
+// The value returned is dst, for easier method chaining
+//
+// If vn and addend are not the same size, this function will add min(vn.Size(), addend.Size())
+// elements.
+func (vn *VecN) Sub(dst *VecN, addend *VecN) *VecN {
+	if vn == nil || addend == nil {
+		return nil
+	}
+	size := intMin(len(vn.vec), len(addend.vec))
+	dst = dst.Resize(size)
+
+	for i := 0; i < size; i++ {
+		dst.vec[i] = vn.vec[i] - addend.vec[i]
+	}
+
+	return dst
+}
+
+// Takes the binary cross product of vn and other, and stores it in dst.
+// If either vn or other are not of size 3 this function will panic
+//
+// If dst is not of sufficient size, or is nil, a new slice is allocated.
+// Dst is permitted to be one of the other arguments
+func (vn *VecN) Cross(dst *VecN, other *VecN) *VecN {
+	if vn == nil || other == nil {
+		return nil
+	}
+	if len(vn.vec) != 3 || len(other.vec) != 3 {
+		panic("Cannot take binary cross product of non-3D elements (7D cross product not implemented)")
+	}
+
+	dst = dst.Resize(3)
+	dst.vec[0], dst.vec[1], dst.vec[2] = vn.vec[1]*other.vec[2]-vn.vec[2]*other.vec[1], vn.vec[2]*other.vec[0]-vn.vec[0]*other.vec[2], vn.vec[0]*other.vec[1]-vn.vec[1]*other.vec[0]
+
+	return dst
+}
+
+func intMin(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+func intAbs(a int) int {
+	if a < 0 {
+		return -a
+	}
+
+	return a
+}
+
+// Computes the dot product of two VecNs, if
+// the two vectors are not of the same length -- this
+// will return NaN.
+func (vn *VecN) Dot(other *VecN) float32 {
+	if vn == nil || other == nil || len(vn.vec) != len(other.vec) {
+		return float32(math.NaN())
+	}
+
+	var result float32 = 0.0
+	for i, el := range vn.vec {
+		result += el * other.vec[i]
+	}
+
+	return result
+}
+
+// Computes the vector length (also called the Norm) of the
+// vector. Equivalent to math.Sqrt(vn.Dot(vn)) with the appropriate
+// type conversions.
+//
+// If vn is nil, this returns NaN
+func (vn *VecN) Len() float32 {
+	if vn == nil {
+		return float32(math.NaN())
+	}
+	if len(vn.vec) == 0 {
+		return 0
+	}
+
+	return float32(math.Sqrt(float64(vn.Dot(vn))))
+}
+
+// Normalizes the vector and stores the result in dst, which
+// will be returned. Dst will be appropraitely resized to the
+// size of vn.
+//
+// The destination can be vn itself and nothing will go wrong.
+//
+// This is equivalent to vn.Mul(dst, 1/vn.Len())
+func (vn *VecN) Normalize(dst *VecN) *VecN {
+	if vn == nil {
+		return nil
+	}
+
+	return vn.Mul(dst, 1/vn.Len())
+}
+
+// Multiplied the vector by some scalar value and stores the result in dst, which
+// will be returned. Dst will be appropraitely resized to the
+// size of vn.
+//
+// The destination can be vn itself and nothing will go wrong.
+func (vn *VecN) Mul(dst *VecN, c float32) *VecN {
+	if vn == nil {
+		return nil
+	}
+	dst = dst.Resize(len(vn.vec))
+
+	for i, el := range vn.vec {
+		dst.vec[i] = el * c
+	}
+
+	return dst
+}
+
+// Performs the vector outer product between vn and v2.
+// The outer product is like a "reverse" dot product. Where the dot product
+// aligns both vectors with the "sized" part facing "inward" (Vec3*Vec3=Mat1x3*Mat3x1=Mat1x1=Scalar).
+// The outer product multiplied them with it facing "outward"
+// (Vec3*Vec3=Mat3x1*Mat1x3=Mat3x3).
+//
+// The matrix dst will be Reshaped to the correct size, if vn or v2 are nil,
+// this returns nil.
+func (vn *VecN) OuterProd(dst *MatMxN, v2 *VecN) *MatMxN {
+	if vn == nil || v2 == nil {
+		return nil
+	}
+
+	dst = dst.Reshape(len(vn.vec), len(v2.vec))
+
+	for c, el1 := range v2.vec {
+		for r, el2 := range vn.vec {
+			dst.Set(r, c, el1*el2)
+		}
+	}
+
+	return dst
+}
+
+func (vn *VecN) ApproxEqual(vn2 *VecN) bool {
+	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
+		return false
+	}
+
+	for i, el := range vn.vec {
+		if !FloatEqual(el, vn2.vec[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (vn *VecN) ApproxEqualThreshold(vn2 *VecN, epsilon float32) bool {
+	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
+		return false
+	}
+
+	for i, el := range vn.vec {
+		if !FloatEqualThreshold(el, vn2.vec[i], epsilon) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (vn *VecN) ApproxEqualFunc(vn2 *VecN, comp func(float32, float32) bool) bool {
+	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
+		return false
+	}
+
+	for i, el := range vn.vec {
+		if !comp(el, vn2.vec[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/mgl32/vecn_test.go
+++ b/mgl32/vecn_test.go
@@ -1,0 +1,119 @@
+package mgl32
+
+import (
+	"testing"
+)
+
+func TestVecNCross(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Cross(v2)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Cross(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN cross product is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNDot(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Dot(v2)
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Dot(v2n)
+
+	if !FloatEqualThreshold(correct, result, 1e-4) {
+		t.Errorf("Dot product doesn't work for VecN. Got: %v, Expected: %v", result, correct)
+	}
+}
+
+func TestVecNMul(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+
+	correct := v1.Mul(3)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+
+	result := v1n.Mul(nil, 3)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN scalar multiplication is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNNormalize(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+
+	correct := v1.Normalize()
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+
+	result := v1n.Normalize(nil)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN normalization is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNAdd(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Add(v2)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Add(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN addition is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNSub(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Sub(v2)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Sub(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN subtraction is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNOuterProd(t *testing.T) {
+	v1 := Vec3{1, 2, 3}
+	v2 := Vec2{10, 11}
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	correct := v1.OuterProd2(v2)
+	correctN := NewMatrixFromData(correct[:], 3, 2)
+
+	result := v1n.OuterProd(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN outer product is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}

--- a/mgl64/doc.go
+++ b/mgl64/doc.go
@@ -14,5 +14,9 @@ instead, as all basic functions are documented.
 
 This package is written in Column Major Order to make it easier with OpenGL. This means for uniform blocks you can use the default ordering, and when you call
 pass-in functions you can leave the "transpose" argument as false.
+
+The package now contains variable sized vectors and matrices. Using these is discouraged. They exist for corner cases where you need "small" matrices that are still
+bigger than 4x4. An example may be a Jacobean used for inverse kinematics. Things like computer vision or general linear algebra are best left to packages
+more directly suited for that task -- OpenCV, BLAS, LAPACK, numpy, gonum (if you want to stay in Go), and so on.
 */
 package mgl64

--- a/mgl64/matmn.go
+++ b/mgl64/matmn.go
@@ -1,0 +1,481 @@
+package mgl64
+
+import (
+	"math"
+)
+
+// An arbitrary mxn matrix backed by a slice of floats.
+//
+// This is emphatically not recommended for hardcore n-dimensional
+// linear algebra. For that purpose I recommend github.com/gonum/matrix or
+// well-tested C libraries such as BLAS or LAPACK.
+//
+// This is meant to complement future algorithms that may require matrices larger than
+// 4x4, but still relatively small (e.g. Jacobeans for inverse kinematics).
+//
+// It makes use of the same memory sync.Pool set that VecN does, with the same sizing rules.
+//
+// MatMN will always check if the receiver is nil on any method. Meaning MathMN(nil).Add(dst,m2)
+// should always work. Except for the Reshape function, the semantics of this is to "propogate" nils
+// forward, so if an invalid operation occurs in a long chain of matrix operations, the overall result will be nil.
+type MatMxN struct {
+	m, n int
+	dat  []float64
+}
+
+// Creates a matrix backed by a new slice of size m*n
+func NewMatrix(m, n int) (mat *MatMxN) {
+	return &MatMxN{m: m, n: n, dat: grabFromPool(m * n)}
+}
+
+// Returns a matrix with data specified by the data in src
+//
+// For instance, to create a 3x3 MatMN from a Mat3
+//
+//    m1 := mgl32.Rotate3DX(3.14159)
+//    mat := mgl32.NewBackedMatrix(m1[:],3,3)
+//
+// will create an MN matrix matching the data in the original
+// rotation matrix. This matrix is NOT backed by the initial slice;
+// it's a copy of the data
+//
+// If m*n > cap(src), this function will panic.
+func NewMatrixFromData(src []float64, m, n int) *MatMxN {
+	internal := grabFromPool(m * n)
+	copy(internal, src[:m*n])
+
+	return &MatMxN{m: m, n: n, dat: internal}
+}
+
+// Copies src into dst. This Reshapes dst
+// to the same size as src.
+//
+// If dst or src is nil, this is a no-op
+func CopyMatMN(dst, src *MatMxN) {
+	if dst == nil || src == nil {
+		return
+	}
+	dst.Reshape(src.m, src.n)
+	copy(dst.dat, src.dat)
+}
+
+// Stores the NxN identity matrix in dst, reallocating as necessary.
+func IdentN(dst *MatMxN, n int) *MatMxN {
+	dst = dst.Reshape(n, n)
+
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				dst.Set(i, j, 1)
+			} else {
+				dst.Set(i, j, 0)
+			}
+		}
+	}
+
+	return dst
+}
+
+// Creates an NxN diagonal matrix seeded by the diagonal vector
+// diag. Meaning: for all entries, where i==j, dst.At(i,j) = diag[i]. Otherwise
+// dst.At(i,j) = 0
+//
+// This reshapes dst to the correct size, returning/grabbing from the memory pool as necessary.
+func DiagN(dst *MatMxN, diag *VecN) *MatMxN {
+	dst = dst.Reshape(len(diag.vec), len(diag.vec))
+	n := len(diag.vec)
+
+	for i := 0; i < n; i++ {
+		for j := 0; j < n; j++ {
+			if i == j {
+				dst.Set(i, j, diag.vec[i])
+			} else {
+				dst.Set(i, j, 0)
+			}
+		}
+	}
+
+	return dst
+}
+
+// Reshapes the matrix to m by n and zeroes out all
+// elements.
+func (mat *MatMxN) Zero(m, n int) {
+	if mat == nil {
+		return
+	}
+
+	mat.Reshape(m, n)
+	for i := range mat.dat {
+		mat.dat[i] = 0
+	}
+}
+
+// Returns the underlying matrix slice to the memory pool
+func (mat *MatMxN) destroy() {
+	if mat == nil {
+		return
+	}
+
+	if mat.dat != nil {
+		returnToPool(mat.dat)
+	}
+	mat.m, mat.n = 0, 0
+	mat.dat = nil
+}
+
+// Reshapes the matrix to the desired dimensions.
+// If the overall size of the new matrix (m*n) is bigger
+// than the current size, the underlying slice will
+// be grown, sending the current slice to the memory pool
+// and grabbing a bigger one if necessary
+//
+// If the caller is a nil pointer, the return value will be a new
+// matrix, as if NewMatrix(m,n) had been called. Otherwise it's
+// simply the caller.
+func (mat *MatMxN) Reshape(m, n int) *MatMxN {
+	if mat == nil {
+		return NewMatrix(m, n)
+	}
+
+	if m*n <= cap(mat.dat) {
+		if mat.dat != nil {
+			mat.dat = mat.dat[:m*n]
+		} else {
+			mat.dat = []float64{}
+		}
+		mat.m, mat.n = m, n
+		return mat
+	}
+
+	if mat.dat != nil {
+		returnToPool(mat.dat)
+	}
+	mat.dat = grabFromPool(m * n)
+	mat.m, mat.n = m, n
+
+	return mat
+}
+
+// Infers an MxN matrix from a constant matrix from this package. For instance,
+// a Mat2x3 inferred with this function will work just like NewMatrixFromData(m[:],2,3)
+// where m is the Mat2x3. This uses a type switch.
+//
+// I personally recommend using NewMatrixFromData, because it avoids a potentially costly type switch.
+// However, this is also more robust and less error prone if you change the size of your matrix somewhere.
+//
+// If the value passed in is not recognized, it returns an InferMatrixError.
+func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
+	switch raw := m.(type) {
+	case Mat2:
+		return NewMatrixFromData(raw[:], 2, 2), nil
+	case Mat2x3:
+		return NewMatrixFromData(raw[:], 2, 3), nil
+	case Mat2x4:
+		return NewMatrixFromData(raw[:], 2, 4), nil
+	case Mat3:
+		return NewMatrixFromData(raw[:], 3, 3), nil
+	case Mat3x2:
+		return NewMatrixFromData(raw[:], 3, 2), nil
+	case Mat3x4:
+		return NewMatrixFromData(raw[:], 3, 4), nil
+	case Mat4:
+		return NewMatrixFromData(raw[:], 4, 4), nil
+	case Mat4x2:
+		return NewMatrixFromData(raw[:], 4, 2), nil
+	case Mat4x3:
+		return NewMatrixFromData(raw[:], 4, 3), nil
+	default:
+		return nil, InferMatrixError{}
+	}
+}
+
+// Returns the trace of a square matrix (sum of all diagonal elements). If the matrix
+// is nil, or not square, the result will be NaN.
+func (mat *MatMxN) Trace() float64 {
+	if mat == nil || mat.m != mat.n {
+		return float64(math.NaN())
+	}
+
+	var out float64
+	for i := 0; i < mat.m; i++ {
+		out += mat.At(i, i)
+	}
+
+	return out
+}
+
+// Takes the transpose of mat and puts it in dst.
+//
+// If dst is not of the correct dimensions, it will be Reshaped,
+// if dst and mat are the same, a temporary matrix of the correct size will
+// be allocated; these resources will be released via the memory pool if
+// it is registered. This should be improved in the future.
+func (mat *MatMxN) Transpose(dst *MatMxN) (t *MatMxN) {
+	if mat == nil {
+		return nil
+	}
+
+	if dst == mat {
+		dst = NewMatrix(mat.n, mat.m)
+
+		// Copy data to correct matrix,
+		// delete temporary buffer,
+		// and set the return value to the
+		// correct one
+		defer func() {
+			copy(mat.dat, dst.dat)
+
+			mat.m, mat.n = mat.n, mat.m
+
+			dst.destroy()
+			t = mat
+		}()
+
+		return mat
+	} else {
+		dst = dst.Reshape(mat.n, mat.m)
+	}
+
+	for r := 0; r < mat.m; r++ {
+		for c := 0; c < mat.n; c++ {
+			dst.dat[r*dst.m+c] = mat.dat[c*mat.m+r]
+		}
+	}
+
+	return dst
+}
+
+// Returns the raw slice backing this matrix
+func (mat *MatMxN) Raw() []float64 {
+	if mat == nil {
+		return nil
+	}
+
+	return mat.dat
+}
+
+// Returns the number of rows in this matrix
+func (mat *MatMxN) NumRows() int {
+	return mat.m
+}
+
+// Returns the number of columns in this matrix
+func (mat *MatMxN) NumCols() int {
+	return mat.n
+}
+
+// Returns the number of rows and columns in this matrix
+// as a single operation
+func (mat *MatMxN) NumRowCols() (rows, cols int) {
+	return mat.m, mat.n
+}
+
+// Returns the element at the given row and column.
+// This is garbage in/garbage out and does no bounds
+// checking. If the computation happens to lead to an invalid
+// element, it will be returned; or it may panic.
+func (mat *MatMxN) At(row, col int) float64 {
+	return mat.dat[col*mat.m+row]
+}
+
+// Sets the element at the given row and column.
+// This is garbage in/garbage out and does no bounds
+// checking. If the computation happens to lead to an invalid
+// element, it will be set; or it may panic.
+func (mat *MatMxN) Set(row, col int, val float64) {
+	mat.dat[col*mat.m+row] = val
+}
+
+func (mat *MatMxN) Add(dst *MatMxN, addend *MatMxN) *MatMxN {
+	if mat == nil || addend == nil || mat.m != addend.m || mat.n != addend.n {
+		return nil
+	}
+
+	dst = dst.Reshape(mat.m, mat.n)
+
+	// No need to care about rows and columns
+	// since it's element-wise anyway
+	for i, el := range mat.dat {
+		dst.dat[i] = el + addend.dat[i]
+	}
+
+	return dst
+}
+
+func (mat *MatMxN) Sub(dst *MatMxN, minuend *MatMxN) *MatMxN {
+	if mat == nil || minuend == nil || mat.m != minuend.m || mat.n != minuend.n {
+		return nil
+	}
+
+	dst = dst.Reshape(mat.m, mat.n)
+
+	// No need to care about rows and columns
+	// since it's element-wise anyway
+	for i, el := range mat.dat {
+		dst.dat[i] = el - minuend.dat[i]
+	}
+
+	return dst
+}
+
+// Performs matrix multiplication on MxN matrix mat and NxO matrix mul, storing the result in dst.
+// This returns dst, or nil if the operation is not able to be performed.
+//
+// If mat == dst, or mul == dst a temporary matrix will be used.
+//
+// This uses the naive algorithm (though on smaller matrices,
+// this can actually be faster; about len(mat)+len(mul) < ~100)
+func (mat *MatMxN) MulMxN(dst *MatMxN, mul *MatMxN) *MatMxN {
+	if mat == nil || mul == nil || mat.n != mul.m {
+		return nil
+	}
+
+	if dst == mul {
+		mul = &MatMxN{m: mul.m, n: mul.n, dat: make([]float64, mul.m*mul.n)}
+		copy(mul.dat, dst.dat)
+
+		// If mul==dst==mul, we need to change
+		// mat too or we have a bug
+		if mul == dst {
+			mat = mul
+		}
+
+		defer mul.destroy()
+	} else if dst == mat {
+		mat = &MatMxN{m: mat.m, n: mat.n, dat: make([]float64, mat.m*mat.n)}
+		copy(mat.dat, dst.dat)
+
+		defer mat.destroy()
+	}
+
+	dst = dst.Reshape(mat.m, mul.n)
+	for r1 := 0; r1 < mat.m; r1++ {
+		for c2 := 0; c2 < mul.n; c2++ {
+
+			dst.dat[c2*mat.m+r1] = 0
+			for i := 0; i < mat.n; i++ {
+				dst.dat[c2*mat.m+r1] += mat.dat[i*mat.m+r1] * mul.dat[c2*mul.m+i]
+			}
+
+		}
+	}
+
+	return dst
+}
+
+// Performs a scalar multiplication between mat and some constant c,
+// storing the result in dst. Mat and dst can be equal. If dst is not the
+// correct size, a Reshape will occur.
+func (mat *MatMxN) Mul(dst *MatMxN, c float64) *MatMxN {
+	if mat == nil {
+		return nil
+	}
+
+	dst = dst.Reshape(mat.m, mat.n)
+
+	for i, el := range mat.dat {
+		dst.dat[i] = el * c
+	}
+
+	return dst
+}
+
+// Multiplies the matrix by a vector of size n. If mat or v is
+// nil, this returns nil. If the number of columns in mat does not match
+// the Size of v, this also returns nil.
+//
+// Dst will be resized if it's not big enough. If dst == v; a temporary
+// vector will be allocated and returned via the realloc callback when complete.
+func (mat *MatMxN) MulNx1(dst, v *VecN) *VecN {
+	if mat == nil || v == nil || mat.n != len(v.vec) {
+		return nil
+	}
+	if dst == v {
+		v = &VecN{make([]float64, len(v.vec))}
+		copy(v.vec, dst.vec)
+
+		defer v.destroy()
+	}
+
+	dst = dst.Resize(len(v.vec))
+
+	for r := range v.vec {
+		dst.vec[r] = 0
+
+		for c := 0; c < mat.n; c++ {
+			dst.vec[r] += mat.At(r, c) * v.vec[c]
+		}
+	}
+
+	return dst
+}
+
+func (mat *MatMxN) ApproxEqual(m2 *MatMxN) bool {
+	if mat == m2 {
+		return true
+	}
+	if mat.m != m2.m || mat.n != m2.n {
+		return false
+	}
+
+	for i, el := range mat.dat {
+		if !FloatEqual(el, m2.dat[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (mat *MatMxN) ApproxEqualThreshold(m2 *MatMxN, epsilon float64) bool {
+	if mat == m2 {
+		return true
+	}
+	if mat.m != m2.m || mat.n != m2.n {
+		return false
+	}
+
+	for i, el := range mat.dat {
+		if !FloatEqualThreshold(el, m2.dat[i], epsilon) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (mat *MatMxN) ApproxEqualFunc(m2 *MatMxN, comp func(float64, float64) bool) bool {
+	if mat == m2 {
+		return true
+	}
+	if mat.m != m2.m || mat.n != m2.n {
+		return false
+	}
+
+	for i, el := range mat.dat {
+		if !comp(el, m2.dat[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type InferMatrixError struct{}
+
+func (me InferMatrixError) Error() string {
+	return "could not infer matrix. Make sure you're using a constant matrix such as Mat3 from within the same package (meaning: mgl32.MatMxN can't handle a mgl64.Mat2x3)."
+}
+
+type RectangularMatrixError struct{}
+
+func (mse RectangularMatrixError) Error() string {
+	return "the matrix was the wrong shape, needed a square matrix."
+}
+
+type NilMatrixError struct{}
+
+func (me NilMatrixError) Error() string {
+	return "the matrix is nil"
+}

--- a/mgl64/matmn_test.go
+++ b/mgl64/matmn_test.go
@@ -1,0 +1,167 @@
+package mgl64
+
+import (
+	"testing"
+)
+
+func TestMxNTransposeWide(t *testing.T) {
+	m := Mat2x3FromCols(
+		Vec2{1, 2},
+		Vec2{3, 4},
+		Vec2{5, 6},
+	)
+
+	mn := NewMatrixFromData(m[:], 2, 3)
+
+	transpose := m.Transpose()
+
+	transposeMN := mn.Transpose(nil)
+
+	correct := NewMatrixFromData(transpose[:], 3, 2)
+
+	if !correct.ApproxEqualThreshold(transposeMN, 1e-4) {
+		t.Errorf("Transpose gives incorrect result; got: %v, expected: %v", transposeMN, correct)
+	}
+}
+
+func TestMxNTransposeTall(t *testing.T) {
+	m := Mat3x2FromCols(
+		Vec3{1, 2, 3},
+		Vec3{4, 5, 6},
+	)
+
+	mn := NewMatrixFromData(m[:], 3, 2)
+
+	transpose := m.Transpose()
+
+	transposeMN := mn.Transpose(nil)
+
+	correct := NewMatrixFromData(transpose[:], 2, 3)
+
+	if !correct.ApproxEqualThreshold(transposeMN, 1e-4) {
+		t.Errorf("Transpose gives incorrect result; got: %v, expected: %v", transposeMN, correct)
+	}
+}
+
+func TestMxNTransposeSquare(t *testing.T) {
+	m := Mat3FromCols(
+		Vec3{1, 2, 3},
+		Vec3{4, 5, 6},
+		Vec3{7, 8, 9},
+	)
+
+	mn := NewMatrixFromData(m[:], 3, 3)
+
+	transpose := m.Transpose()
+
+	transposeMN := mn.Transpose(nil)
+
+	correct := NewMatrixFromData(transpose[:], 3, 3)
+
+	if !correct.ApproxEqualThreshold(transposeMN, 1e-4) {
+		t.Errorf("Transpose gives incorrect result; got: %v, expected: %v", transposeMN, correct)
+	}
+}
+
+func TestMxNAtSet(t *testing.T) {
+	m := Mat3{1, 2, 3, 4, 5, 6, 7, 8, 9}
+
+	mn := NewMatrixFromData(m[:], 3, 3)
+
+	v := mn.At(0, 2)
+
+	if !FloatEqualThreshold(v, 7, 1e-4) {
+		t.Errorf("Incorrect value gotten by At: %v, expected %v", v, 7)
+	}
+
+	mn.Set(0, 2, 9001)
+
+	v = mn.At(0, 2)
+
+	if !FloatEqualThreshold(v, 9001, 1e-4) {
+		t.Errorf("Incorrect value set by Set: %v, expected %v", v, 9001)
+	}
+
+	correct := Mat3{1, 2, 3, 4, 5, 6, 9001, 8, 9}
+	correctMN := NewMatrixFromData(correct[:], 3, 3)
+
+	if !correctMN.ApproxEqualThreshold(mn, 1e-4) {
+		t.Errorf("Set matrix does not equal correct matrix. Got: %v, expected: %v", mn, correctMN)
+	}
+}
+
+func TestMxNMulMxN(t *testing.T) {
+	m := Ident4()
+	r := HomogRotate3DX(DegToRad(45))
+	tr := Translate3D(1, 0, 0)
+	s := Scale3D(2, 2, 2)
+
+	correct := tr.Mul4(r.Mul4(s.Mul4(m))) // tr*r*s
+	correctMN := NewMatrixFromData(correct[:], 4, 4)
+
+	mn := NewMatrixFromData(m[:], 4, 4)
+	rmn := NewMatrixFromData(r[:], 4, 4)
+	trmn := NewMatrixFromData(tr[:], 4, 4)
+	smn := NewMatrixFromData(s[:], 4, 4)
+
+	result := trmn.MulMxN(nil, rmn.MulMxN(nil, smn.MulMxN(nil, mn)))
+
+	if !result.ApproxEqualThreshold(correctMN, 1e-4) {
+		t.Errorf("Multiplication of MxN matrix and 4x4 matrix not the same. Got: %v expected: %v", result, correctMN)
+	}
+}
+
+func TestMxNMulMxNErrorHandling(t *testing.T) {
+	mn := NewMatrix(4, 12)
+	mn2 := NewMatrix(9, 3)
+
+	result := mn2.MulMxN(nil, mn)
+
+	if result != nil {
+		t.Errorf("Nil not returned for bad matrix multiplication, got %v instead", result)
+	}
+}
+
+func TestMxNMul(t *testing.T) {
+	m := Mat3{2, 4, 6, 1, 9, 12, 7, 4, 3}
+	mn := NewMatrixFromData(m[:], 3, 3)
+
+	correct := m.Mul(15)
+	correctMN := NewMatrixFromData(correct[:], 3, 3)
+
+	result := mn.Mul(nil, 15)
+
+	if !correctMN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("Scaling a matrix produces weird results got: %v, expected: %v", result, correct)
+	}
+}
+
+func TestMxNMulNx1(t *testing.T) {
+	m := Ident4()
+	r := HomogRotate3DX(DegToRad(45))
+	tr := Translate3D(1, 0, 0)
+	s := Scale3D(2, 2, 2)
+
+	model := tr.Mul4(r.Mul4(s.Mul4(m)))
+
+	v := Vec4{5, 5, 5, 1}
+	correct := model.Mul4x1(v)
+	correctn := NewVecNFromData(correct[:])
+
+	modelMN := NewMatrixFromData(model[:], 4, 4)
+	vn := NewVecNFromData(v[:])
+
+	result := modelMN.MulNx1(nil, vn)
+
+	if !correctn.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("Multiplying N-dim vector and MxN matrix produces bad result. Got: %v, expected: %v", result, correct)
+	}
+}
+
+func TestMxNTrace(t *testing.T) {
+	m := DiagN(nil, NewVecNFromData([]float64{1, 2, 3, 4, 5}))
+
+	if !FloatEqualThreshold(m.Trace(), 15, 1e-4) {
+		t.Errorf("MatMxN's trace of a diagonal with 1,2,3,4,5 is not 15. Got: %v", m.Trace())
+	}
+}

--- a/mgl64/mempool.go
+++ b/mgl64/mempool.go
@@ -1,0 +1,111 @@
+package mgl64
+
+import (
+	"sync"
+)
+
+var (
+	slicePools []*sync.Pool
+	listLock   sync.RWMutex
+)
+
+// Returns the given memory pool. If the pool doesn't exist, it will
+// create all pools up to element i. The number "i" corresponds to "p"
+// in most other comments. That is, it's Ceil(log_2(whatever)). So i=0
+// means you'll get the pool for slices of size 1, i=1 for size 2, i=2 for size 4,
+// and so on.
+//
+// This is concurrency safe and uses an RWMutex to protect the list expansion.
+func getPool(i int) *sync.Pool {
+	listLock.RLock()
+	if i >= len(slicePools) {
+
+		// Promote to a write lock because we now
+		// need to mutate the pool
+		listLock.RUnlock()
+		listLock.Lock()
+		defer listLock.Unlock()
+
+		for n := i - len(slicePools); n >= 0; n-- {
+			newFunc := genPoolNew(1 << uint(len(slicePools)))
+			slicePools = append(slicePools, &sync.Pool{New: newFunc})
+		}
+	} else {
+		defer listLock.RUnlock()
+	}
+
+	return slicePools[i]
+}
+
+func genPoolNew(i int) func() interface{} {
+	return func() interface{} {
+		return make([]float64, 0, i)
+	}
+}
+
+// Grabs a slice from the memory pool, such that its cap
+// is 2^p where p is Ceil(log_2(size)). It will be downsliced
+// such that the cap is size.
+func grabFromPool(size int) []float64 {
+	pool, exact := binLog(size)
+
+	// Tried to grab something of size
+	// zero or less
+	if pool == -1 {
+		return nil
+	}
+
+	// If the log is not exact, we
+	// need to "overallocate" so we have
+	// log+1
+	if !exact {
+		pool++
+	}
+
+	slice := getPool(pool).Get().([]float64)
+	slice = slice[:size]
+	return slice
+}
+
+// Returns a slice to the appropriate pool. If the slice does not have a cap that's precisely
+// a power of 2, this will panic.
+func returnToPool(slice []float64) {
+	if cap(slice) == 0 {
+		return
+	}
+
+	pool, exact := binLog(cap(slice))
+
+	if !exact {
+		panic("attempt to pool slice with non-exact cap. If you're a user, please file an issue with github.com/go-gl/mathgl about this bug. This should never happen.")
+	}
+
+	getPool(pool).Put(slice)
+}
+
+// This returns the integer base 2 log of the value
+// and whether the log is exact or rounded down.
+//
+// This is only for positive integers.
+//
+// There are faster ways to do this, I'm open to suggestions. Most rely on knowing system endianness
+// which Go makes hard to do. I'm hesistant to use float conversions and the math package because of off-by-one errors.
+func binLog(val int) (int, bool) {
+	if val <= 0 {
+		return -1, false
+	}
+
+	exact := true
+	l := 0
+	for ; val > 1; val = val >> 1 {
+		// If the current lsb is 1 and the number
+		// is not equal to 1, this is not an exact
+		// log, but rather a rounding of it
+		if val&1 != 0 {
+			exact = false
+		}
+		l++
+	}
+
+	return l, exact
+}

--- a/mgl64/mempool_test.go
+++ b/mgl64/mempool_test.go
@@ -1,0 +1,71 @@
+package mgl64
+
+import (
+	"testing"
+)
+
+func TestBinLog(t *testing.T) {
+	tests := []struct {
+		in int
+
+		// out
+		val   int
+		exact bool
+	}{
+		{-256, -1, false},
+		{0, -1, false},
+		{1, 0, true},
+		{2, 1, true},
+		{3, 1, false},
+		{32, 5, true},
+		{37, 5, false},
+	}
+
+	for _, test := range tests {
+		outV, outE := binLog(test.in)
+		if outV != test.val || outE != test.exact {
+			t.Errorf("binLog gives incorrect result for input %v. Got: (%v,%v); Expected: (%v,%v)", test.in, outV, outE, test.val, test.exact)
+		}
+	}
+}
+
+func TestGetPool(t *testing.T) {
+	slicePools = nil
+	pool := getPool(3)
+
+	if len(slicePools) != 4 || pool == nil {
+		t.Errorf("Couldn't get pool. Size of slice %v (should be 4)", len(slicePools))
+	}
+
+	slice, ok := pool.Get().([]float64)
+	if slice == nil || !ok || cap(slice) != 1<<3 {
+		t.Errorf("Slice from pool either not allocated, not ok, or of wrong cap. Got slice: %v, ok: %v, cap: %v", slice, ok, cap(slice))
+	}
+}
+
+func TestGrabFromPool(t *testing.T) {
+	slicePools = nil
+	slice := grabFromPool(17)
+
+	if slice == nil || len(slice) != 17 || cap(slice) != 32 {
+		t.Errorf("Got bad, ill sized, or badly capped slice from grabFromPool. Slice: %v, len: %v, cap: %v", slice, len(slice), cap(slice))
+	}
+}
+
+func BenchmarkBinLogReasonable(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _ = binLog(100)
+	}
+}
+
+func BenchmarkBinLogBig(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _ = binLog(1<<30 + 1)
+	}
+}
+
+func BenchmarkBinLogSmall(b *testing.B) {
+	for n := 0; n < b.N; n++ {
+		_, _ = binLog(10)
+	}
+}

--- a/mgl64/vecn.go
+++ b/mgl64/vecn.go
@@ -1,0 +1,323 @@
+package mgl64
+
+import (
+	"math"
+)
+
+// A vector of N elements backed by a slice
+//
+// As with MatMxN, this is not for hardcore linear algebra with large dimensions. Use github.com/gonum/matrix
+// or something like BLAS/LAPACK for that. This is for corner cases in 3D math where you require
+// something a little bigger that 4D, but still relatively small.
+//
+// This VecN uses several sync.Pool objects as a memory pool. The rule is that for any sized vector, the backing slice
+// has CAPACITY (not length) of 2^p where p is Ceil(log_2(N)) -- or in other words, rounding up the base-2
+// log of the size of the vector. E.G. a VecN of size 17 will have a backing slice of Cap 32.
+type VecN struct {
+	vec []float64
+}
+
+// Creates a new vector with a backing slice filled with the contents
+// of initial. It is NOT backed by initial, but rather a slice with cap
+// 2^p where p is Ceil(log_2(len(initial))), with the data from initial copied into
+// it.
+func NewVecNFromData(initial []float64) *VecN {
+	if initial == nil {
+		return &VecN{}
+	}
+	internal := grabFromPool(len(initial))
+	copy(internal, initial)
+	return &VecN{vec: internal}
+}
+
+// Creates a new vector with a backing slice of
+// 2^p where p = Ceil(log_2(n))
+func NewVecN(n int) *VecN {
+	return &VecN{vec: grabFromPool(n)}
+}
+
+// Returns the raw slice backing the VecN
+//
+// This may be sent back to the memory pool at any time
+// and you aren't advised to rely on this value
+func (vn VecN) Raw() []float64 {
+	return vn.vec
+}
+
+// Gets the element at index i from the vector.
+// This does not bounds check, and will panic if i is
+// out of range.
+func (vn VecN) Get(i int) float64 {
+	return vn.vec[i]
+}
+
+// Sends the allocated memory through the callback if it exists
+func (vn *VecN) destroy() {
+	if vn == nil || vn.vec == nil {
+		return
+	}
+
+	returnToPool(vn.vec)
+	vn.vec = nil
+}
+
+// Resizes the underlying slice to the desired amount, reallocating or retrieving from the pool
+// if necessary. This does not zero any values.
+//
+// If the caller is a nil pointer, this returns a value as if NewVecN(n) had been called,
+// otherwise it simply returns the caller.
+func (vn *VecN) Resize(n int) *VecN {
+	if vn == nil {
+		return NewVecN(n)
+	}
+
+	if n <= cap(vn.vec) {
+		if vn.vec != nil {
+			vn.vec = vn.vec[:n]
+		} else {
+			vn.vec = []float64{}
+		}
+		return vn
+	}
+
+	if vn.vec != nil {
+		returnToPool(vn.vec)
+	}
+	vn.vec = grabFromPool(n)
+	return vn
+}
+
+// Sets the vector's backing slice to the given
+// new one.
+func (vn *VecN) SetBackingSlice(newSlice []float64) {
+	vn.vec = newSlice
+}
+
+// Return the len of the vector's underlying slice.
+// This is not titled Len because it conflicts the package's
+// convention of calling the Norm the Len.
+func (vn *VecN) Size() int {
+	return len(vn.vec)
+}
+
+// Returns the cap of the vector's underlying slice.
+func (vn *VecN) Cap() int {
+	return cap(vn.vec)
+}
+
+// Sets the vector's size to n and zeroes out the vector.
+// If n is bigger than the vector's size, it will realloc.
+func (vn *VecN) Zero(n int) {
+	vn.Resize(n)
+	for i := range vn.vec {
+		vn.vec[i] = 0
+	}
+}
+
+// Adds vn and addend, storing the result in dst.
+// If dst does not have sufficient size it will be resized
+// Dst may be one of the other arguments. If dst is nil, it will be allocated.
+// The value returned is dst, for easier method chaining
+//
+// If vn and addend are not the same size, this function will add min(vn.Size(), addend.Size())
+// elements.
+func (vn *VecN) Add(dst *VecN, minuend *VecN) *VecN {
+	if vn == nil || minuend == nil {
+		return nil
+	}
+	size := intMin(len(vn.vec), len(minuend.vec))
+	dst = dst.Resize(size)
+
+	for i := 0; i < size; i++ {
+		dst.vec[i] = vn.vec[i] + minuend.vec[i]
+	}
+
+	return dst
+}
+
+// Subtracts addend from vn, storing the result in dst.
+// If dst does not have sufficient size it will be resized
+// Dst may be one of the other arguments. If dst is nil, it will be allocated.
+// The value returned is dst, for easier method chaining
+//
+// If vn and addend are not the same size, this function will add min(vn.Size(), addend.Size())
+// elements.
+func (vn *VecN) Sub(dst *VecN, addend *VecN) *VecN {
+	if vn == nil || addend == nil {
+		return nil
+	}
+	size := intMin(len(vn.vec), len(addend.vec))
+	dst = dst.Resize(size)
+
+	for i := 0; i < size; i++ {
+		dst.vec[i] = vn.vec[i] - addend.vec[i]
+	}
+
+	return dst
+}
+
+// Takes the binary cross product of vn and other, and stores it in dst.
+// If either vn or other are not of size 3 this function will panic
+//
+// If dst is not of sufficient size, or is nil, a new slice is allocated.
+// Dst is permitted to be one of the other arguments
+func (vn *VecN) Cross(dst *VecN, other *VecN) *VecN {
+	if vn == nil || other == nil {
+		return nil
+	}
+	if len(vn.vec) != 3 || len(other.vec) != 3 {
+		panic("Cannot take binary cross product of non-3D elements (7D cross product not implemented)")
+	}
+
+	dst = dst.Resize(3)
+	dst.vec[0], dst.vec[1], dst.vec[2] = vn.vec[1]*other.vec[2]-vn.vec[2]*other.vec[1], vn.vec[2]*other.vec[0]-vn.vec[0]*other.vec[2], vn.vec[0]*other.vec[1]-vn.vec[1]*other.vec[0]
+
+	return dst
+}
+
+func intMin(a, b int) int {
+	if a < b {
+		return a
+	}
+
+	return b
+}
+
+func intAbs(a int) int {
+	if a < 0 {
+		return -a
+	}
+
+	return a
+}
+
+// Computes the dot product of two VecNs, if
+// the two vectors are not of the same length -- this
+// will return NaN.
+func (vn *VecN) Dot(other *VecN) float64 {
+	if vn == nil || other == nil || len(vn.vec) != len(other.vec) {
+		return float64(math.NaN())
+	}
+
+	var result float64 = 0.0
+	for i, el := range vn.vec {
+		result += el * other.vec[i]
+	}
+
+	return result
+}
+
+// Computes the vector length (also called the Norm) of the
+// vector. Equivalent to math.Sqrt(vn.Dot(vn)) with the appropriate
+// type conversions.
+//
+// If vn is nil, this returns NaN
+func (vn *VecN) Len() float64 {
+	if vn == nil {
+		return float64(math.NaN())
+	}
+	if len(vn.vec) == 0 {
+		return 0
+	}
+
+	return float64(math.Sqrt(float64(vn.Dot(vn))))
+}
+
+// Normalizes the vector and stores the result in dst, which
+// will be returned. Dst will be appropraitely resized to the
+// size of vn.
+//
+// The destination can be vn itself and nothing will go wrong.
+//
+// This is equivalent to vn.Mul(dst, 1/vn.Len())
+func (vn *VecN) Normalize(dst *VecN) *VecN {
+	if vn == nil {
+		return nil
+	}
+
+	return vn.Mul(dst, 1/vn.Len())
+}
+
+// Multiplied the vector by some scalar value and stores the result in dst, which
+// will be returned. Dst will be appropraitely resized to the
+// size of vn.
+//
+// The destination can be vn itself and nothing will go wrong.
+func (vn *VecN) Mul(dst *VecN, c float64) *VecN {
+	if vn == nil {
+		return nil
+	}
+	dst = dst.Resize(len(vn.vec))
+
+	for i, el := range vn.vec {
+		dst.vec[i] = el * c
+	}
+
+	return dst
+}
+
+// Performs the vector outer product between vn and v2.
+// The outer product is like a "reverse" dot product. Where the dot product
+// aligns both vectors with the "sized" part facing "inward" (Vec3*Vec3=Mat1x3*Mat3x1=Mat1x1=Scalar).
+// The outer product multiplied them with it facing "outward"
+// (Vec3*Vec3=Mat3x1*Mat1x3=Mat3x3).
+//
+// The matrix dst will be Reshaped to the correct size, if vn or v2 are nil,
+// this returns nil.
+func (vn *VecN) OuterProd(dst *MatMxN, v2 *VecN) *MatMxN {
+	if vn == nil || v2 == nil {
+		return nil
+	}
+
+	dst = dst.Reshape(len(vn.vec), len(v2.vec))
+
+	for c, el1 := range v2.vec {
+		for r, el2 := range vn.vec {
+			dst.Set(r, c, el1*el2)
+		}
+	}
+
+	return dst
+}
+
+func (vn *VecN) ApproxEqual(vn2 *VecN) bool {
+	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
+		return false
+	}
+
+	for i, el := range vn.vec {
+		if !FloatEqual(el, vn2.vec[i]) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (vn *VecN) ApproxEqualThreshold(vn2 *VecN, epsilon float64) bool {
+	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
+		return false
+	}
+
+	for i, el := range vn.vec {
+		if !FloatEqualThreshold(el, vn2.vec[i], epsilon) {
+			return false
+		}
+	}
+
+	return true
+}
+
+func (vn *VecN) ApproxEqualFunc(vn2 *VecN, comp func(float64, float64) bool) bool {
+	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
+		return false
+	}
+
+	for i, el := range vn.vec {
+		if !comp(el, vn2.vec[i]) {
+			return false
+		}
+	}
+
+	return true
+}

--- a/mgl64/vecn_test.go
+++ b/mgl64/vecn_test.go
@@ -1,0 +1,119 @@
+package mgl64
+
+import (
+	"testing"
+)
+
+func TestVecNCross(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Cross(v2)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Cross(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN cross product is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNDot(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Dot(v2)
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Dot(v2n)
+
+	if !FloatEqualThreshold(correct, result, 1e-4) {
+		t.Errorf("Dot product doesn't work for VecN. Got: %v, Expected: %v", result, correct)
+	}
+}
+
+func TestVecNMul(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+
+	correct := v1.Mul(3)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+
+	result := v1n.Mul(nil, 3)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN scalar multiplication is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNNormalize(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+
+	correct := v1.Normalize()
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+
+	result := v1n.Normalize(nil)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN normalization is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNAdd(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Add(v2)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Add(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN addition is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNSub(t *testing.T) {
+	v1 := Vec3{1, 3, 5}
+	v2 := Vec3{2, 4, 6}
+
+	correct := v1.Sub(v2)
+	correctN := NewVecNFromData(correct[:])
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	result := v1n.Sub(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN subtraction is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}
+
+func TestVecNOuterProd(t *testing.T) {
+	v1 := Vec3{1, 2, 3}
+	v2 := Vec2{10, 11}
+
+	v1n := NewVecNFromData(v1[:])
+	v2n := NewVecNFromData(v2[:])
+
+	correct := v1.OuterProd2(v2)
+	correctN := NewMatrixFromData(correct[:], 3, 2)
+
+	result := v1n.OuterProd(nil, v2n)
+
+	if !correctN.ApproxEqualThreshold(result, 1e-4) {
+		t.Errorf("VecN outer product is incorrect. Got: %v; Expected: %v", result, correctN)
+	}
+}


### PR DESCRIPTION
This adds basic support for arbitrary sized vectors and matrices. Additional functionality will be added in time. This requires Go 1.3 since it makes use of sync.Pool. This is _not_ for true n-dim linear algebra, but rather corner cases where you require matrices a little larger than what is provided.
