### PR TITLE
Use new x/image/math/{f32,f64} packages internally.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,23 +1,10 @@
 language: go
-
 go:
- - 1.3
-
+  - 1.4
 install:
-   # - wget -q https://raw.github.com/go-gl/testutils/master/travis-helper-functions.sh
-   # - source travis-helper-functions.sh
-   #- initialize
-
+  - go get golang.org/x/tools/cmd/vet
 script:
-  - go test -v ./...
- 
-
-after_failure: failure
-after_error: failure
-
-notifications:
-  email:
-    recipients:
-      - jragonmiris@gmail.com
-    on_success: change
-    on_failure: always
+  - go get -t -v ./...
+  - diff -u <(echo -n) <(gofmt -d ./)
+  - go tool vet ./
+  - go test -v -race ./...

--- a/genprog/main.go
+++ b/genprog/main.go
@@ -59,11 +59,8 @@ import(
 
 `
 
-	for m := 2; m <= 4; m++ {
-		vecs += GenVecDef(m)
-	}
+	// Skip Vec2, Vec3, Vec4 types since they're in vectorStatic.go.
 
-	vecs += "\n"
 	for m := 2; m <= 4; m++ {
 		vecs += GenVecAdd(m)
 	}
@@ -123,23 +120,23 @@ import(
 
 func GenVecCross() string {
 	header := `// The vector cross product is an operation only defined on 3D vectors. It is equivalent to
-// Vec3{v1[1]*v2[2]-v1[2]*v2[1], v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}. 
-// Another interpretation is that it's the vector whose magnitude is |v1||v2|sin(theta) 
+// Vec3{v1[1]*v2[2]-v1[2]*v2[1], v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}.
+// Another interpretation is that it's the vector whose magnitude is |v1||v2|sin(theta)
 // where theta is the angle between v1 and v2.
 //
 // The cross product is most often used for finding surface normals. The cross product of vectors
 // will generate a vector that is perpendicular to the plane they form.
 //
-// Technically, a generalized cross product exists as an "(N-1)ary" operation 
+// Technically, a generalized cross product exists as an "(N-1)ary" operation
 // (that is, the 4D cross product requires 3 4D vectors). But the binary
-// 3D (and 7D) cross product is the most important. It can be considered 
+// 3D (and 7D) cross product is the most important. It can be considered
 // the area of a parallelogram with sides v1 and v2.
 //
-// Like the dot product, the cross product is roughly a measure of directionality. 
+// Like the dot product, the cross product is roughly a measure of directionality.
 // Two normalized perpendicular vectors will return a vector with a magnitude of
-// 1.0 or -1.0 and two parallel vectors will return a vector with magnitude 0.0. 
+// 1.0 or -1.0 and two parallel vectors will return a vector with magnitude 0.0.
 // The cross product is "anticommutative" meaning v1.Cross(v2) = -v2.Cross(v1),
-// this property can be useful to know when finding normals, 
+// this property can be useful to know when finding normals,
 // as taking the wrong cross product can lead to the opposite normal of the one you want.
 `
 	return header + "func (v1 Vec3) Cross(v2 Vec3) Vec3 {\n\treturn Vec3{v1[1]*v2[2]-v1[2]*v2[1], v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}\n}\n\n"
@@ -242,7 +239,7 @@ func GenVecDot(m int) (s string) {
 func GenVecLen(m int) (s string) {
 	s = `// Len returns the vector's length. Note that this is NOT the dimension of
 // the vector (len(v)), but the mathematical length. This is equivalent to the square
-// root of the sum of the squares of all elements. E.G. for a Vec2 it's 
+// root of the sum of the squares of all elements. E.G. for a Vec2 it's
 // math.Hypot(v[0], v[1]).
 `
 	if m != 2 {
@@ -413,6 +410,11 @@ import(
 
 	for m := 2; m <= 4; m++ {
 		for n := 2; n <= 4; n++ {
+			// Skip Mat3 and Mat4 since they're declared in matrixStatic.go.
+			if (m == n) && (m == 3 || m == 4) {
+				continue
+			}
+
 			mats += GenMatDef(m, n)
 		}
 	}
@@ -669,7 +671,7 @@ func GenTranspose(m, n int) (s string) {
 //
 //    [[a b]]    [[a c e]]
 //    [[c d]] =  [[b d f]]
-//    [[e f]]    
+//    [[e f]]
 `
 	s += fmt.Sprintf("func (m1 %s) Transpose() %s {\n\treturn %s{", GenMatName(m, n), GenMatName(n, m), GenMatName(n, m))
 
@@ -741,10 +743,10 @@ func GenInv(m int) string {
 // In this library, the math is precomputed, and uses no loops, though the multiplications, additions, determinant calculation, and scaling
 // are still done. This can still be (relatively) expensive for a 4x4.
 //
-// This function checks the determinant to see if the matrix is invertible. 
+// This function checks the determinant to see if the matrix is invertible.
 // If the determinant is 0.0, this function returns the zero matrix. However, due to floating point errors, it is
 // entirely plausible to get a false positive or negative.
-// In the future, an alternate function may be written which takes in a pre-computed determinant. 
+// In the future, an alternate function may be written which takes in a pre-computed determinant.
 `
 	s += fmt.Sprintf("func (m %s) Inv() %s {\n\t", GenMatName(m, m), GenMatName(m, m))
 	s += "det := m.Det()\n\t if FloatEqual(det,float32(0.0)) { \n\t\t return " + GenMatName(m, m) + "{}\n\t}\n\t"

--- a/mgl32/matrix.go
+++ b/mgl32/matrix.go
@@ -19,11 +19,9 @@ type Mat2 [4]float32
 type Mat2x3 [6]float32
 type Mat2x4 [8]float32
 type Mat3x2 [6]float32
-type Mat3 [9]float32
 type Mat3x4 [12]float32
 type Mat4x2 [8]float32
 type Mat4x3 [12]float32
-type Mat4 [16]float32
 
 // Ident<N> returns the NxN identity matrix.
 // The identity matrix is a square matrix with the value 1 on its

--- a/mgl32/matrixStatic.go
+++ b/mgl32/matrixStatic.go
@@ -4,6 +4,11 @@
 
 package mgl32
 
+import "golang.org/x/image/math/f32"
+
+type Mat3 f32.Mat3
+type Mat4 f32.Mat4
+
 // Sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]

--- a/mgl32/matstack/transformStack.go
+++ b/mgl32/matstack/transformStack.go
@@ -170,5 +170,5 @@ type NoInverseError struct {
 }
 
 func (nie NoInverseError) Error() string {
-	return fmt.Sprintf("cannot find inverse of matrix %v at location %d in matrix stack, aborting rebase/reseed")
+	return fmt.Sprintf("cannot find inverse of matrix %v at location %d in matrix stack, aborting rebase/reseed", nie.Mat, nie.Loc)
 }

--- a/mgl32/project_test.go
+++ b/mgl32/project_test.go
@@ -25,7 +25,7 @@ func TestProject(t *testing.T) {
 
 	objr, err := UnProject(win, modelview, projection, initialX, initialY, width, height)
 	if err != nil {
-		t.Errorf("UnProject returned error:", err)
+		t.Errorf("UnProject returned error: %v", err)
 	}
 	if !objr.ApproxEqualThreshold(obj, 1e-4) {
 		t.Errorf("UnProject(%v) != %v (got %v)", win, obj, objr)

--- a/mgl32/transform_test.go
+++ b/mgl32/transform_test.go
@@ -116,7 +116,7 @@ func TestExtractMaxScale(t *testing.T) {
 	eq := FloatEqualFunc(1e-6)
 	for _, c := range tests {
 		if r := ExtractMaxScale(c.M); !eq(r, c.V) {
-			t.Errorf("ExtractMaxScale(%v) != %v (got %v, %v, %v)", c.M, c.V, r)
+			t.Errorf("ExtractMaxScale(%v) != %v (got %v)", c.M, c.V, r)
 		}
 	}
 }

--- a/mgl32/vector.go
+++ b/mgl32/vector.go
@@ -12,10 +12,6 @@ import (
 	"math"
 )
 
-type Vec2 [2]float32
-type Vec3 [3]float32
-type Vec4 [4]float32
-
 // Add performs element-wise addition between two vectors. It is equivalent to iterating
 // over every element of v1 and adding the corresponding element of v2 to it.
 func (v1 Vec2) Add(v2 Vec2) Vec2 {

--- a/mgl32/vectorStatic.go
+++ b/mgl32/vectorStatic.go
@@ -4,6 +4,12 @@
 
 package mgl32
 
+import "golang.org/x/image/math/f32"
+
+type Vec2 f32.Vec2
+type Vec3 f32.Vec3
+type Vec4 f32.Vec4
+
 func (v Vec2) Vec3(z float32) Vec3 {
 	return Vec3{v[0], v[1], z}
 }

--- a/mgl64/matrix.go
+++ b/mgl64/matrix.go
@@ -19,11 +19,9 @@ type Mat2 [4]float64
 type Mat2x3 [6]float64
 type Mat2x4 [8]float64
 type Mat3x2 [6]float64
-type Mat3 [9]float64
 type Mat3x4 [12]float64
 type Mat4x2 [8]float64
 type Mat4x3 [12]float64
-type Mat4 [16]float64
 
 // Ident<N> returns the NxN identity matrix.
 // The identity matrix is a square matrix with the value 1 on its

--- a/mgl64/matrixStatic.go
+++ b/mgl64/matrixStatic.go
@@ -4,6 +4,11 @@
 
 package mgl64
 
+import "golang.org/x/image/math/f64"
+
+type Mat3 f64.Mat3
+type Mat4 f64.Mat4
+
 // Sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]

--- a/mgl64/project_test.go
+++ b/mgl64/project_test.go
@@ -25,7 +25,7 @@ func TestProject(t *testing.T) {
 
 	objr, err := UnProject(win, modelview, projection, initialX, initialY, width, height)
 	if err != nil {
-		t.Errorf("UnProject returned error:", err)
+		t.Errorf("UnProject returned error: %v", err)
 	}
 	if !objr.ApproxEqualThreshold(obj, 1e-4) {
 		t.Errorf("UnProject(%v) != %v (got %v)", win, obj, objr)

--- a/mgl64/transform_test.go
+++ b/mgl64/transform_test.go
@@ -116,7 +116,7 @@ func TestExtractMaxScale(t *testing.T) {
 	eq := FloatEqualFunc(1e-6)
 	for _, c := range tests {
 		if r := ExtractMaxScale(c.M); !eq(r, c.V) {
-			t.Errorf("ExtractMaxScale(%v) != %v (got %v, %v, %v)", c.M, c.V, r)
+			t.Errorf("ExtractMaxScale(%v) != %v (got %v)", c.M, c.V, r)
 		}
 	}
 }

--- a/mgl64/vector.go
+++ b/mgl64/vector.go
@@ -12,10 +12,6 @@ import (
 	"math"
 )
 
-type Vec2 [2]float64
-type Vec3 [3]float64
-type Vec4 [4]float64
-
 // Add performs element-wise addition between two vectors. It is equivalent to iterating
 // over every element of v1 and adding the corresponding element of v2 to it.
 func (v1 Vec2) Add(v2 Vec2) Vec2 {

--- a/mgl64/vectorStatic.go
+++ b/mgl64/vectorStatic.go
@@ -4,6 +4,12 @@
 
 package mgl64
 
+import "golang.org/x/image/math/f64"
+
+type Vec2 f64.Vec2
+type Vec3 f64.Vec3
+type Vec4 f64.Vec4
+
 func (v Vec2) Vec3(z float64) Vec3 {
 	return Vec3{v[0], v[1], z}
 }


### PR DESCRIPTION
This is an internal code change, public API remains unchanged. No existing code should break.

The idea is to start using the new x/image/math/{f32,f64} packages that were finally added to Go (external) standard library. This is just a code organization change with no effect, but it will help us guide towards more standardization in the future. The underlying types are identical.

I've updated `genprog/main.go` to match, but I could not run it (aside from testing) because of #34.

Please review.

One observation I've made from making this PR is that everything works, but x/image/math/... is missing `Mat2` type that mathgl has.