### PR TITLE
Fixed arguments names for Ortho2D

### DIFF
--- a/mgl32/project.go
+++ b/mgl32/project.go
@@ -16,8 +16,8 @@ func Ortho(left, right, bottom, top, near, far float32) Mat4 {
 }
 
 // Equivalent to Ortho with the near and far planes being -1 and 1, respectively
-func Ortho2D(left, right, top, bottom float32) Mat4 {
-	return Ortho(left, right, top, bottom, -1, 1)
+func Ortho2D(left, right, bottom, top float32) Mat4 {
+	return Ortho(left, right, bottom, top, -1, 1)
 }
 
 func Perspective(fovy, aspect, near, far float32) Mat4 {

--- a/mgl64/project.go
+++ b/mgl64/project.go
@@ -16,8 +16,8 @@ func Ortho(left, right, bottom, top, near, far float64) Mat4 {
 }
 
 // Equivalent to Ortho with the near and far planes being -1 and 1, respectively
-func Ortho2D(left, right, top, bottom float64) Mat4 {
-	return Ortho(left, right, top, bottom, -1, 1)
+func Ortho2D(left, right, bottom, top float64) Mat4 {
+	return Ortho(left, right, bottom, top, -1, 1)
 }
 
 func Perspective(fovy, aspect, near, far float64) Mat4 {


### PR DESCRIPTION
Changed order of `Ortho2D` arguments to match `Ortho`.