### PR TITLE
matstack: Fix missing return on error.

### DIFF
--- a/mgl32/matstack/matstack.go
+++ b/mgl32/matstack/matstack.go
@@ -24,7 +24,7 @@ func (ms *MatStack) Push() {
 // there is an error.
 func (ms *MatStack) Pop() error {
 	if len(*ms) == 1 {
-		errors.New("Cannot pop from mat stack, at minimum stack length of 1")
+		return errors.New("Cannot pop from mat stack, at minimum stack length of 1")
 	}
 	(*ms) = (*ms)[:len(*ms)-1]
 

--- a/mgl64/matstack/matstack.go
+++ b/mgl64/matstack/matstack.go
@@ -26,7 +26,7 @@ func (ms *MatStack) Push() {
 // there is an error.
 func (ms *MatStack) Pop() error {
 	if len(*ms) == 1 {
-		errors.New("Cannot pop from mat stack, at minimum stack length of 1")
+		return errors.New("Cannot pop from mat stack, at minimum stack length of 1")
 	}
 	(*ms) = (*ms)[:len(*ms)-1]
 


### PR DESCRIPTION
It was caught by Travis running vet:

```
$ go tool vet ./
mgl32/matstack/matstack.go:27: result of errors.New call not used
mgl64/matstack/matstack.go:29: result of errors.New call not used

The command "go tool vet ./" exited with 1.
```

This fixes Travis build.