### PR TITLE
Make repo friendly to standard `go generate ./...`.

### DIFF
--- a/mgl32/codegen.go
+++ b/mgl32/codegen.go
@@ -16,7 +16,7 @@ import (
 	"bytes"
 	"flag"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -118,11 +118,10 @@ func genMgl64(destPath string) {
 			return nil
 		}
 
-		in, err := os.Open(source)
+		in, err := ioutil.ReadFile(source)
 		if err != nil {
 			return err
 		}
-		defer in.Close()
 
 		out, err := os.OpenFile(dest, os.O_RDWR|os.O_CREATE|os.O_TRUNC,
 			info.Mode())
@@ -138,7 +137,9 @@ func genMgl64(destPath string) {
 			return err
 		}
 
-		if _, err = io.Copy(out, in); err != nil {
+		r := strings.NewReplacer("//go:generate ", "//#go:generate ") // We don't want go generate directives in mgl64 package.
+
+		if _, err = r.WriteString(out, string(in)); err != nil {
 			return err
 		}
 

--- a/mgl64/util.go
+++ b/mgl64/util.go
@@ -4,9 +4,9 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-//go:generate go run codegen.go -template vector.tmpl -output vector.go
-//go:generate go run codegen.go -template matrix.tmpl -output matrix.go
-//go:generate go run codegen.go -mgl64
+//#go:generate go run codegen.go -template vector.tmpl -output vector.go
+//#go:generate go run codegen.go -template matrix.tmpl -output matrix.go
+//#go:generate go run codegen.go -mgl64
 
 package mgl64
 


### PR DESCRIPTION
Currently, the standard way to generate this repo is to run `go generate github.com/go-gl/mathgl/mgl32`. It generates parts of mgl32 package, and all of mg64 package. In the process of generating mg64, it copies over the go generate directives. But they are invalid, and running `go generate github.com/go-gl/mathgl/mgl64` produces an error. Doing that should be a safe no-op.

This change fixes that by replacing "//go:generate " directives with a disabled version "//#go:generate " when copying over mgl32 files to mgl64 package.

As a result, doing `go generate github.com/go-gl/mathgl/...` works as expected without problems and correctly generates all packages in this repo.

Hopefully it'll help avoid issues like https://github.com/go-gl/mathgl/pull/46#issuecomment-133938858 and make contributing slightly easier.