### PR TITLE
Project fix

### DIFF
--- a/mgl32/project.go
+++ b/mgl32/project.go
@@ -62,6 +62,7 @@ func Project(obj Vec3, modelview, projection Mat4, initialX, initialY, width, he
 	obj4 := obj.Vec4(1)
 
 	vpp := projection.Mul4(modelview).Mul4x1(obj4)
+	vpp = vpp.Mul(1 / vpp.W())
 	win[0] = float32(initialX) + (float32(width)*(vpp[0]+1))/2
 	win[1] = float32(initialY) + (float32(height)*(vpp[1]+1))/2
 	win[2] = (vpp[2] + 1) / 2

--- a/mgl32/project_test.go
+++ b/mgl32/project_test.go
@@ -32,8 +32,7 @@ func TestProject(t *testing.T) {
 	}
 }
 
-
-// Test from 
+// Test from
 // http://stackoverflow.com/questions/38471708/opengl-glm-project-method-giving-unexpected-results
 func TestProjectNonOneW(t *testing.T) {
 	t.Parallel()
@@ -41,19 +40,18 @@ func TestProjectNonOneW(t *testing.T) {
 	obj := Vec3{5, 0, 0}
 
 	projection := Perspective(
-    DegToRad(45), // Field of view (45 degrees).
-    800.0 / 600.0,      // Aspect ratio.
-    0.1,                // Near Z at 0.1.
-    10)                 // Far Z at 10.
+		DegToRad(45), // Field of view (45 degrees).
+		800.0/600.0,  // Aspect ratio.
+		0.1,          // Near Z at 0.1.
+		10)           // Far Z at 10.
 	camera := LookAtV(
-	    Vec3{0, 0.1, 10}, // Camera out on Z and slightly above.
-	    Vec3{0, 0, 0},    // Looking at the origin.
-	    Vec3{0, 1, 0})    // Up is positive Y.
-	model := Ident4()     // Simple model matrix, to avoid confusion.
+		Vec3{0, 0.1, 10}, // Camera out on Z and slightly above.
+		Vec3{0, 0, 0},    // Looking at the origin.
+		Vec3{0, 1, 0})    // Up is positive Y.
+	model := Ident4()               // Simple model matrix, to avoid confusion.
 	modelView := camera.Mul4(model) // The model-view matrix (== camera, here).
 
 	win := Project(obj, modelView, projection, 0, 0, 800, 600)
-
 
 	t.Logf("Test:   (%v, %v, %v)", win[0], win[1], win[2])
 

--- a/mgl32/project_test.go
+++ b/mgl32/project_test.go
@@ -32,6 +32,38 @@ func TestProject(t *testing.T) {
 	}
 }
 
+
+// Test from 
+// http://stackoverflow.com/questions/38471708/opengl-glm-project-method-giving-unexpected-results
+func TestProjectNonOneW(t *testing.T) {
+	t.Parallel()
+
+	obj := Vec3{5, 0, 0}
+
+	projection := Perspective(
+    DegToRad(45), // Field of view (45 degrees).
+    800.0 / 600.0,      // Aspect ratio.
+    0.1,                // Near Z at 0.1.
+    10)                 // Far Z at 10.
+	camera := LookAtV(
+	    Vec3{0, 0.1, 10}, // Camera out on Z and slightly above.
+	    Vec3{0, 0, 0},    // Looking at the origin.
+	    Vec3{0, 1, 0})    // Up is positive Y.
+	model := Ident4()     // Simple model matrix, to avoid confusion.
+	modelView := camera.Mul4(model) // The model-view matrix (== camera, here).
+
+	win := Project(obj, modelView, projection, 0, 0, 800, 600)
+
+
+	t.Logf("Test:   (%v, %v, %v)", win[0], win[1], win[2])
+
+	answer := Vec3{762.114, 300, 1} // verified with glm
+
+	if !win.ApproxEqualThreshold(answer, 1e-4) {
+		t.Errorf("Project does not properly do perspective division, differs from expected by %v", win.Sub(answer).Len())
+	}
+}
+
 func TestUnprojectSingular(t *testing.T) {
 	if _, err := UnProject(Vec3{}, Mat4{}, Mat4{}, 0, 0, 2048, 1152); err == nil {
 		t.Errorf("Did not get error from UnProject on singular matrix")

--- a/mgl64/matstack/matstack.go
+++ b/mgl64/matstack/matstack.go
@@ -1,4 +1,4 @@
-// This file is generated from mgl32/matstack/matstack.go; DO NOT EDIT
+// This file is generated from mgl32/matstack\matstack.go; DO NOT EDIT
 
 package matstack
 

--- a/mgl64/matstack/transformStack.go
+++ b/mgl64/matstack/transformStack.go
@@ -1,4 +1,4 @@
-// This file is generated from mgl32/matstack/transformStack.go; DO NOT EDIT
+// This file is generated from mgl32/matstack\transformStack.go; DO NOT EDIT
 
 package matstack
 

--- a/mgl64/matstack/transformstack_test.go
+++ b/mgl64/matstack/transformstack_test.go
@@ -1,4 +1,4 @@
-// This file is generated from mgl32/matstack/transformstack_test.go; DO NOT EDIT
+// This file is generated from mgl32/matstack\transformstack_test.go; DO NOT EDIT
 
 package matstack
 

--- a/mgl64/project.go
+++ b/mgl64/project.go
@@ -64,6 +64,7 @@ func Project(obj Vec3, modelview, projection Mat4, initialX, initialY, width, he
 	obj4 := obj.Vec4(1)
 
 	vpp := projection.Mul4(modelview).Mul4x1(obj4)
+	vpp = vpp.Mul(1 / vpp.W())
 	win[0] = float64(initialX) + (float64(width)*(vpp[0]+1))/2
 	win[1] = float64(initialY) + (float64(height)*(vpp[1]+1))/2
 	win[2] = (vpp[2] + 1) / 2

--- a/mgl64/project_test.go
+++ b/mgl64/project_test.go
@@ -34,6 +34,36 @@ func TestProject(t *testing.T) {
 	}
 }
 
+// Test from
+// http://stackoverflow.com/questions/38471708/opengl-glm-project-method-giving-unexpected-results
+func TestProjectNonOneW(t *testing.T) {
+	t.Parallel()
+
+	obj := Vec3{5, 0, 0}
+
+	projection := Perspective(
+		DegToRad(45), // Field of view (45 degrees).
+		800.0/600.0,  // Aspect ratio.
+		0.1,          // Near Z at 0.1.
+		10)           // Far Z at 10.
+	camera := LookAtV(
+		Vec3{0, 0.1, 10}, // Camera out on Z and slightly above.
+		Vec3{0, 0, 0},    // Looking at the origin.
+		Vec3{0, 1, 0})    // Up is positive Y.
+	model := Ident4()               // Simple model matrix, to avoid confusion.
+	modelView := camera.Mul4(model) // The model-view matrix (== camera, here).
+
+	win := Project(obj, modelView, projection, 0, 0, 800, 600)
+
+	t.Logf("Test:   (%v, %v, %v)", win[0], win[1], win[2])
+
+	answer := Vec3{762.114, 300, 1} // verified with glm
+
+	if !win.ApproxEqualThreshold(answer, 1e-4) {
+		t.Errorf("Project does not properly do perspective division, differs from expected by %v", win.Sub(answer).Len())
+	}
+}
+
 func TestUnprojectSingular(t *testing.T) {
 	if _, err := UnProject(Vec3{}, Mat4{}, Mat4{}, 0, 0, 2048, 1152); err == nil {
 		t.Errorf("Did not get error from UnProject on singular matrix")


### PR DESCRIPTION
Fixes #60 (for both 32 and 64). Also appears to change a lot of forward slashes to backslashes in comments, which I think may be a minor bug with our go generate script on Windows? Either way, this is a bug fix so that's probably not worth worrying about.