### PR TITLE
Updated the documentation to mention the HomogRotate3D requires a normalised axis vector.

### DIFF
--- a/mgl32/transform.go
+++ b/mgl32/transform.go
@@ -147,7 +147,7 @@ func ShearZ3D(shearX, shearY float32) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, 1, 0, 0, float32(shearX), float32(shearY), 1, 0, 0, 0, 0, 1}
 }
 
-// HomogRotate3D creates a 3D rotation Matrix that rotates by (radian) angle about some arbitrary axis given by a Vector.
+// HomogRotate3D creates a 3D rotation Matrix that rotates by (radian) angle about some arbitrary axis given by a normalized Vector.
 // It produces a homogeneous matrix (4x4)
 //
 // Where c is cos(angle) and s is sin(angle), and x, y, and z are the first, second, and third elements of the axis vector (respectively):

--- a/mgl32/transform_test.go
+++ b/mgl32/transform_test.go
@@ -61,6 +61,26 @@ func TestHomogRotate3D(t *testing.T) {
 				0, 0, 0, 1,
 			},
 		},
+		{
+			"heading and attitude 90 degree",
+			DegToRad(90), Vec3{0, 1, 1}.Normalize(),
+			Mat4{
+				0, 0.707107, -0.707107, 0,
+				-0.707107, 0.5, 0.5, 0,
+				0.707107, 0.5, 0.5, 0,
+				0, 0, 0, 1,
+			},
+		},
+		{
+			"bank, heading and attitude 180 degree",
+			DegToRad(180), Vec3{1, 1, 1}.Normalize(),
+			Mat4{
+				-1 / 3.0, 2 / 3.0, 2 / 3.0, 0,
+				2 / 3.0, -1 / 3.0, 2 / 3.0, 0,
+				2 / 3.0, 2 / 3.0, -1 / 3.0, 0,
+				0, 0, 0, 1,
+			},
+		},
 	}
 
 	threshold := float32(math.Pow(10, -2))

--- a/mgl64/transform.go
+++ b/mgl64/transform.go
@@ -149,7 +149,7 @@ func ShearZ3D(shearX, shearY float64) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, 1, 0, 0, float64(shearX), float64(shearY), 1, 0, 0, 0, 0, 1}
 }
 
-// HomogRotate3D creates a 3D rotation Matrix that rotates by (radian) angle about some arbitrary axis given by a Vector.
+// HomogRotate3D creates a 3D rotation Matrix that rotates by (radian) angle about some arbitrary axis given by a normalized Vector.
 // It produces a homogeneous matrix (4x4)
 //
 // Where c is cos(angle) and s is sin(angle), and x, y, and z are the first, second, and third elements of the axis vector (respectively):

--- a/mgl64/transform_test.go
+++ b/mgl64/transform_test.go
@@ -63,6 +63,26 @@ func TestHomogRotate3D(t *testing.T) {
 				0, 0, 0, 1,
 			},
 		},
+		{
+			"heading and attitude 90 degree",
+			DegToRad(90), Vec3{0, 1, 1}.Normalize(),
+			Mat4{
+				0, 0.707107, -0.707107, 0,
+				-0.707107, 0.5, 0.5, 0,
+				0.707107, 0.5, 0.5, 0,
+				0, 0, 0, 1,
+			},
+		},
+		{
+			"bank, heading and attitude 180 degree",
+			DegToRad(180), Vec3{1, 1, 1}.Normalize(),
+			Mat4{
+				-1 / 3.0, 2 / 3.0, 2 / 3.0, 0,
+				2 / 3.0, -1 / 3.0, 2 / 3.0, 0,
+				2 / 3.0, 2 / 3.0, -1 / 3.0, 0,
+				0, 0, 0, 1,
+			},
+		},
 	}
 
 	threshold := float64(math.Pow(10, -2))


### PR DESCRIPTION
OpenGL's glm does not require a normalised vector, and porting some C++ to Go bite me. I've
also added a couple of tests for this behaviour, which I confirmed was correct by comparing
to [WolframAlpha](https://www.wolframalpha.com/input/?i=RotationMatrix%5Bpi+%2F+2,+%7B0,+1,+1%7D%5D)