### PR TITLE
fix for issue #65

### DIFF
--- a/mgl32/shapes.go
+++ b/mgl32/shapes.go
@@ -291,16 +291,16 @@ func GLToScreenCoords(x, y float32, screenWidth, screenHeight int) (xOut, yOut i
 	return
 }
 
-func choose(n, k int) (result int) {
+func choose(n, k int) int {
 	if k == 0 {
 		return 1
 	} else if n == 0 {
 		return 0
 	}
-	result = (n - (k - 1))
+	result := float32(n - (k - 1))
 	for i := 2; i <= k; i++ {
-		result *= (n - (k - i)) / i
+		result *= float32(n-(k-i)) / float32(i)
 	}
 
-	return result
+	return int(result)
 }

--- a/mgl32/shapes.go
+++ b/mgl32/shapes.go
@@ -291,6 +291,7 @@ func GLToScreenCoords(x, y float32, screenWidth, screenHeight int) (xOut, yOut i
 	return
 }
 
+// choose calculates the binomial coefficient C(n,k) aka nCk
 func choose(n, k int) int {
 	if k == 0 {
 		return 1

--- a/mgl32/shapes_test.go
+++ b/mgl32/shapes_test.go
@@ -52,3 +52,35 @@ func TestGLToScreenCoords(t *testing.T) {
 		t.Errorf("y = %d, expected 0", y)
 	}
 }
+
+func Test_choose(t *testing.T) {
+	type args struct {
+		n int
+		k []int
+	}
+	tests := []struct {
+		name string
+		args args
+		want []int
+	}{
+		// TODO: Add test cases.
+		{
+			name: "C(2,k)",
+			args: args{n: 2, k: []int{0, 1, 2}},
+			want: []int{1, 2, 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := []int{}
+			fail := false
+			for i, k := range tt.args.k {
+				got = append(got, choose(tt.args.n, k))
+				fail = got[i] != tt.want[i]
+			}
+			if fail {
+				t.Errorf("choose() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/mgl32/shapes_test.go
+++ b/mgl32/shapes_test.go
@@ -54,29 +54,46 @@ func TestGLToScreenCoords(t *testing.T) {
 }
 
 func Test_choose(t *testing.T) {
-	type args struct {
-		n int
-		k []int
-	}
+
 	tests := []struct {
 		name string
-		args args
+		n    int
 		want []int
 	}{
-		// TODO: Add test cases.
+		// test cases.
 		{
 			name: "C(2,k)",
-			args: args{n: 2, k: []int{0, 1, 2}},
+			n:    2,
 			want: []int{1, 2, 1},
+		},
+		{
+			name: "C(3,k)",
+			n:    3,
+			want: []int{1, 3, 3, 1},
+		},
+		{
+			name: "C(4,k)",
+			n:    4,
+			want: []int{1, 4, 6, 4, 1},
+		},
+		{
+			name: "C(5,k)",
+			n:    5,
+			want: []int{1, 5, 10, 10, 5, 1},
+		},
+		{
+			name: "C(6,k)",
+			n:    6,
+			want: []int{1, 6, 15, 20, 25, 6, 1},
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := []int{}
 			fail := false
-			for i, k := range tt.args.k {
-				got = append(got, choose(tt.args.n, k))
-				fail = got[i] != tt.want[i]
+			for k := 0; k < tt.n; k++ {
+				got = append(got, choose(tt.n, k))
+				fail = got[k] != tt.want[k]
 			}
 			if fail {
 				t.Errorf("choose() = %v, want %v", got, tt.want)

--- a/mgl32/shapes_test.go
+++ b/mgl32/shapes_test.go
@@ -88,16 +88,16 @@ func Test_choose(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := []int{}
-			fail := false
-			for k := 0; k < tt.n; k++ {
-				got = append(got, choose(tt.n, k))
-				fail = got[k] != tt.want[k]
-			}
-			if fail {
-				t.Errorf("choose() = %v, want %v", got, tt.want)
-			}
-		})
+		// t.Run(tt.name, func(t *testing.T) {
+		got := []int{}
+		fail := false
+		for k := 0; k < tt.n; k++ {
+			got = append(got, choose(tt.n, k))
+			fail = got[k] != tt.want[k]
+		}
+		if fail {
+			t.Errorf("choose() = %v, want %v", got, tt.want)
+		}
+		// })
 	}
 }

--- a/mgl64/matstack/matstack.go
+++ b/mgl64/matstack/matstack.go
@@ -1,4 +1,4 @@
-// This file is generated from mgl32/matstack\matstack.go; DO NOT EDIT
+// This file is generated from mgl32/matstack/matstack.go; DO NOT EDIT
 
 package matstack
 

--- a/mgl64/matstack/transformStack.go
+++ b/mgl64/matstack/transformStack.go
@@ -1,4 +1,4 @@
-// This file is generated from mgl32/matstack\transformStack.go; DO NOT EDIT
+// This file is generated from mgl32/matstack/transformStack.go; DO NOT EDIT
 
 package matstack
 

--- a/mgl64/matstack/transformstack_test.go
+++ b/mgl64/matstack/transformstack_test.go
@@ -1,4 +1,4 @@
-// This file is generated from mgl32/matstack\transformstack_test.go; DO NOT EDIT
+// This file is generated from mgl32/matstack/transformstack_test.go; DO NOT EDIT
 
 package matstack
 

--- a/mgl64/shapes.go
+++ b/mgl64/shapes.go
@@ -293,16 +293,17 @@ func GLToScreenCoords(x, y float64, screenWidth, screenHeight int) (xOut, yOut i
 	return
 }
 
-func choose(n, k int) (result int) {
+// choose calculates the binomial coefficient C(n,k) aka nCk
+func choose(n, k int) int {
 	if k == 0 {
 		return 1
 	} else if n == 0 {
 		return 0
 	}
-	result = (n - (k - 1))
+	result := float64(n - (k - 1))
 	for i := 2; i <= k; i++ {
-		result *= (n - (k - i)) / i
+		result *= float64(n-(k-i)) / float64(i)
 	}
 
-	return result
+	return int(result)
 }

--- a/mgl64/shapes_test.go
+++ b/mgl64/shapes_test.go
@@ -54,3 +54,52 @@ func TestGLToScreenCoords(t *testing.T) {
 		t.Errorf("y = %d, expected 0", y)
 	}
 }
+
+func Test_choose(t *testing.T) {
+
+	tests := []struct {
+		name string
+		n    int
+		want []int
+	}{
+		// test cases.
+		{
+			name: "C(2,k)",
+			n:    2,
+			want: []int{1, 2, 1},
+		},
+		{
+			name: "C(3,k)",
+			n:    3,
+			want: []int{1, 3, 3, 1},
+		},
+		{
+			name: "C(4,k)",
+			n:    4,
+			want: []int{1, 4, 6, 4, 1},
+		},
+		{
+			name: "C(5,k)",
+			n:    5,
+			want: []int{1, 5, 10, 10, 5, 1},
+		},
+		{
+			name: "C(6,k)",
+			n:    6,
+			want: []int{1, 6, 15, 20, 25, 6, 1},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := []int{}
+			fail := false
+			for k := 0; k < tt.n; k++ {
+				got = append(got, choose(tt.n, k))
+				fail = got[k] != tt.want[k]
+			}
+			if fail {
+				t.Errorf("choose() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/mgl64/shapes_test.go
+++ b/mgl64/shapes_test.go
@@ -90,16 +90,16 @@ func Test_choose(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := []int{}
-			fail := false
-			for k := 0; k < tt.n; k++ {
-				got = append(got, choose(tt.n, k))
-				fail = got[k] != tt.want[k]
-			}
-			if fail {
-				t.Errorf("choose() = %v, want %v", got, tt.want)
-			}
-		})
+		// t.Run(tt.name, func(t *testing.T) {
+		got := []int{}
+		fail := false
+		for k := 0; k < tt.n; k++ {
+			got = append(got, choose(tt.n, k))
+			fail = got[k] != tt.want[k]
+		}
+		if fail {
+			t.Errorf("choose() = %v, want %v", got, tt.want)
+		}
+		// })
 	}
 }


### PR DESCRIPTION
fixes #65 

Per contributing instructions in README, I made the changes in mgl32/shapes.go, added a test (which didn't exist in the original), and ran `go generate` to create the corresponding changes in mgl64. Some files in mgl64/matstack were changed due to the different \ vs / used in paths in windows vs linux.

I ran `Test_choose()` on both the original code (failed of course) and the patch (passed), for verification.