### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/mgl32/matmn.go
+++ b/mgl32/matmn.go
@@ -36,7 +36,7 @@ func NewMatrix(m, n int) (mat *MatMxN) {
 	}
 }
 
-// Returns a matrix with data specified by the data in src
+// NewMatrixFromData returns a matrix with data specified by the data in src
 //
 // For instance, to create a 3x3 MatMN from a Mat3
 //
@@ -202,7 +202,7 @@ func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
 	}
 }
 
-// Returns the trace of a square matrix (sum of all diagonal elements). If the matrix
+// Trace returns the trace of a square matrix (sum of all diagonal elements). If the matrix
 // is nil, or not square, the result will be NaN.
 func (mat *MatMxN) Trace() float32 {
 	if mat == nil || mat.m != mat.n {
@@ -217,7 +217,7 @@ func (mat *MatMxN) Trace() float32 {
 	return out
 }
 
-// Takes the transpose of mat and puts it in dst.
+// Transpose takes the transpose of mat and puts it in dst.
 //
 // If dst is not of the correct dimensions, it will be Reshaped,
 // if dst and mat are the same, a temporary matrix of the correct size will
@@ -259,7 +259,7 @@ func (mat *MatMxN) Transpose(dst *MatMxN) (t *MatMxN) {
 	return dst
 }
 
-// Returns the raw slice backing this matrix
+// Raw returns the raw slice backing this matrix
 func (mat *MatMxN) Raw() []float32 {
 	if mat == nil {
 		return nil
@@ -268,23 +268,23 @@ func (mat *MatMxN) Raw() []float32 {
 	return mat.dat
 }
 
-// Returns the number of rows in this matrix
+// NumRows returns the number of rows in this matrix
 func (mat *MatMxN) NumRows() int {
 	return mat.m
 }
 
-// Returns the number of columns in this matrix
+// NumCols returns the number of columns in this matrix
 func (mat *MatMxN) NumCols() int {
 	return mat.n
 }
 
-// Returns the number of rows and columns in this matrix
+// NumRowCols returns the number of rows and columns in this matrix
 // as a single operation
 func (mat *MatMxN) NumRowCols() (rows, cols int) {
 	return mat.m, mat.n
 }
 
-// Returns the element at the given row and column.
+// At returns the element at the given row and column.
 // This is garbage in/garbage out and does no bounds
 // checking. If the computation happens to lead to an invalid
 // element, it will be returned; or it may panic.

--- a/mgl32/matrix.go
+++ b/mgl32/matrix.go
@@ -263,7 +263,7 @@ func (m1 Mat2) ApproxEqualThreshold(m2 Mat2, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2) ApproxFuncEqual(m2 Mat2, eq func(float32, float32) bool) bool {
@@ -487,7 +487,7 @@ func (m1 Mat2x3) ApproxEqualThreshold(m2 Mat2x3, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x3) ApproxFuncEqual(m2 Mat2x3, eq func(float32, float32) bool) bool {
@@ -705,7 +705,7 @@ func (m1 Mat2x4) ApproxEqualThreshold(m2 Mat2x4, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x4) ApproxFuncEqual(m2 Mat2x4, eq func(float32, float32) bool) bool {
@@ -933,7 +933,7 @@ func (m1 Mat3x2) ApproxEqualThreshold(m2 Mat3x2, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x2) ApproxFuncEqual(m2 Mat3x2, eq func(float32, float32) bool) bool {
@@ -1226,7 +1226,7 @@ func (m1 Mat3) ApproxEqualThreshold(m2 Mat3, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3) ApproxFuncEqual(m2 Mat3, eq func(float32, float32) bool) bool {
@@ -1460,7 +1460,7 @@ func (m1 Mat3x4) ApproxEqualThreshold(m2 Mat3x4, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x4) ApproxFuncEqual(m2 Mat3x4, eq func(float32, float32) bool) bool {
@@ -1698,7 +1698,7 @@ func (m1 Mat4x2) ApproxEqualThreshold(m2 Mat4x2, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x2) ApproxFuncEqual(m2 Mat4x2, eq func(float32, float32) bool) bool {
@@ -1936,7 +1936,7 @@ func (m1 Mat4x3) ApproxEqualThreshold(m2 Mat4x3, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x3) ApproxFuncEqual(m2 Mat4x3, eq func(float32, float32) bool) bool {
@@ -2246,7 +2246,7 @@ func (m1 Mat4) ApproxEqualThreshold(m2 Mat4, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4) ApproxFuncEqual(m2 Mat4, eq func(float32, float32) bool) bool {

--- a/mgl32/matstack/matstack.go
+++ b/mgl32/matstack/matstack.go
@@ -20,7 +20,7 @@ func (ms *MatStack) Push() {
 	(*ms) = append(*ms, (*ms)[len(*ms)-1])
 }
 
-// Removes the first element of the matrix from the stack, if there is only one element left
+// Pop removes the first element of the matrix from the stack, if there is only one element left
 // there is an error.
 func (ms *MatStack) Pop() error {
 	if len(*ms) == 1 {
@@ -43,7 +43,7 @@ func (ms *MatStack) LeftMul(m mgl32.Mat4) {
 	(*ms)[len(*ms)-1] = m.Mul4((*ms)[len(*ms)-1])
 }
 
-// Returns the top element.
+// Peek returns the top element.
 func (ms *MatStack) Peek() mgl32.Mat4 {
 	return (*ms)[len(*ms)-1]
 }

--- a/mgl32/matstack/transformStack.go
+++ b/mgl32/matstack/transformStack.go
@@ -16,7 +16,7 @@ import (
 // had been made in the middle.
 type TransformStack []mgl32.Mat4
 
-// Returns a matrix stack where the top element is the identity.
+// NewTransformStack returns a matrix stack where the top element is the identity.
 func NewTransformStack() *TransformStack {
 	ms := make(TransformStack, 1)
 	ms[0] = mgl32.Ident4()
@@ -45,13 +45,13 @@ func (ms *TransformStack) Pop() (mgl32.Mat4, error) {
 	return retVal, nil
 }
 
-// Returns the value of the current top element of the stack, without
+// Peek returns the value of the current top element of the stack, without
 // removing it.
 func (ms *TransformStack) Peek() mgl32.Mat4 {
 	return (*ms)[len(*ms)-1]
 }
 
-// Returns the size of the matrix stack. This value will never be less
+// Len returns the size of the matrix stack. This value will never be less
 // than 1.
 func (ms *TransformStack) Len() int {
 	return len(*ms)

--- a/mgl32/quat.go
+++ b/mgl32/quat.go
@@ -74,7 +74,7 @@ func (q Quat) Z() float32 {
 	return q.V[2]
 }
 
-// Adds two quaternions. It's no more complicated than
+// Add adds two quaternions. It's no more complicated than
 // adding their W and V components.
 func (q1 Quat) Add(q2 Quat) Quat {
 	return Quat{q1.W + q2.W, q1.V.Add(q2.V)}
@@ -98,13 +98,13 @@ func (q1 Quat) Scale(c float32) Quat {
 	return Quat{q1.W * c, Vec3{q1.V[0] * c, q1.V[1] * c, q1.V[2] * c}}
 }
 
-// Returns the conjugate of a quaternion. Equivalent to
+// Conjugate returns the conjugate of a quaternion. Equivalent to
 // Quat{q1.W, q1.V.Mul(-1)}
 func (q1 Quat) Conjugate() Quat {
 	return Quat{q1.W, q1.V.Mul(-1)}
 }
 
-// Returns the Length of the quaternion, also known as its Norm. This is the same thing as
+// Len returns the Length of the quaternion, also known as its Norm. This is the same thing as
 // the Len of a Vec4
 func (q1 Quat) Len() float32 {
 	return float32(math.Sqrt(float64(q1.W*q1.W + q1.V[0]*q1.V[0] + q1.V[1]*q1.V[1] + q1.V[2]*q1.V[2])))
@@ -159,7 +159,7 @@ func (q1 Quat) Rotate(v Vec3) Vec3 {
 	return v.Add(cross.Mul(2 * q1.W)).Add(q1.V.Mul(2).Cross(cross))
 }
 
-// Returns the homogeneous 3D rotation matrix corresponding to the quaternion.
+// Mat4 returns the homogeneous 3D rotation matrix corresponding to the quaternion.
 func (q1 Quat) Mat4() Mat4 {
 	w, x, y, z := q1.W, q1.V[0], q1.V[1], q1.V[2]
 	return Mat4{
@@ -175,25 +175,25 @@ func (q1 Quat) Dot(q2 Quat) float32 {
 	return q1.W*q2.W + q1.V[0]*q2.V[0] + q1.V[1]*q2.V[1] + q1.V[2]*q2.V[2]
 }
 
-// Returns whether the quaternions are approximately equal, as if
+// ApproxEqual returns whether the quaternions are approximately equal, as if
 // FloatEqual was called on each matching element
 func (q1 Quat) ApproxEqual(q2 Quat) bool {
 	return FloatEqual(q1.W, q2.W) && q1.V.ApproxEqual(q2.V)
 }
 
-// Returns whether the quaternions are approximately equal with a given tolerence, as if
+// ApproxEqualThreshold returns whether the quaternions are approximately equal with a given tolerence, as if
 // FloatEqualThreshold was called on each matching element with the given epsilon
 func (q1 Quat) ApproxEqualThreshold(q2 Quat, epsilon float32) bool {
 	return FloatEqualThreshold(q1.W, q2.W, epsilon) && q1.V.ApproxEqualThreshold(q2.V, epsilon)
 }
 
-// Returns whether the quaternions are approximately equal using the given comparison function, as if
+// ApproxEqualFunc returns whether the quaternions are approximately equal using the given comparison function, as if
 // the function had been called on each individual element
 func (q1 Quat) ApproxEqualFunc(q2 Quat, f func(float32, float32) bool) bool {
 	return f(q1.W, q2.W) && q1.V.ApproxFuncEqual(q2.V, f)
 }
 
-// Returns whether the quaternions represents the same orientation
+// OrientationEqual returns whether the quaternions represents the same orientation
 //
 // Different values can represent the same orientation (q == -q) because quaternions avoid singularities
 // and discontinuities involved with rotation in 3 dimensions by adding extra dimensions
@@ -201,7 +201,7 @@ func (q1 Quat) OrientationEqual(q2 Quat) bool {
 	return q1.OrientationEqualThreshold(q2, Epsilon)
 }
 
-// Returns whether the quaternions represents the same orientation with a given tolerence
+// OrientationEqualThreshold returns whether the quaternions represents the same orientation with a given tolerence
 func (q1 Quat) OrientationEqualThreshold(q2 Quat, epsilon float32) bool {
 	return Abs(q1.Normalize().Dot(q2.Normalize())) > 1-epsilon
 }

--- a/mgl32/shapes.go
+++ b/mgl32/shapes.go
@@ -94,7 +94,7 @@ func CubicBezierCurve3D(t float32, cPoint1, cPoint2, cPoint3, cPoint4 Vec3) Vec3
 	return cPoint1.Mul((1 - t) * (1 - t) * (1 - t)).Add(cPoint2.Mul(3 * (1 - t) * (1 - t) * t)).Add(cPoint3.Mul(3 * (1 - t) * t * t)).Add(cPoint4.Mul(t * t * t))
 }
 
-// Returns the point at point t along an n-control point Bezier curve
+// BezierCurve2D returns the point at point t along an n-control point Bezier curve
 //
 // t must be in the range 0.0 and 1.0 or this function will panic. Consider [0.0,1.0] to be similar to a percentage,
 // 0.0 is first control point, and the point at 1.0 is the last control point. Any point in between is how far along the path you are between 0 and 1.
@@ -212,7 +212,7 @@ func BezierSurface(u, v float32, cPoints [][]Vec3) Vec3 {
 	return point
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
+// BezierSplineInterpolate2D Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
 // though the spline may be disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic
@@ -230,7 +230,7 @@ func BezierSplineInterpolate2D(t float32, ranges [][2]float32, cPoints [][]Vec2)
 	panic("t is out of the range of all bezier curves in this spline")
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
+// BezierSplineInterpolate3D Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
 // though the spline may be disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic

--- a/mgl32/util.go
+++ b/mgl32/util.go
@@ -107,7 +107,7 @@ func ClampFunc(low, high float32) func(float32) float32 {
 /* The IsClamped functions use strict equality (meaning: not the FloatEqual function)
 there shouldn't be any major issues with this since clamp is often used to fix minor errors*/
 
-// Checks if a is clamped between low and high as if
+// IsClamped checks if a is clamped between low and high as if
 // Clamp(a, low, high) had been called.
 //
 // In most cases it's probably better to just call Clamp

--- a/mgl32/vecn.go
+++ b/mgl32/vecn.go
@@ -49,7 +49,7 @@ func NewVecN(n int) *VecN {
 	}
 }
 
-// Returns the raw slice backing the VecN
+// Raw returns the raw slice backing the VecN
 //
 // This may be sent back to the memory pool at any time
 // and you aren't advised to rely on this value
@@ -57,7 +57,7 @@ func (vn VecN) Raw() []float32 {
 	return vn.vec
 }
 
-// Gets the element at index i from the vector.
+// Get gets the element at index i from the vector.
 // This does not bounds check, and will panic if i is
 // out of range.
 func (vn VecN) Get(i int) float32 {
@@ -113,14 +113,14 @@ func (vn *VecN) SetBackingSlice(newSlice []float32) {
 	vn.vec = newSlice
 }
 
-// Return the len of the vector's underlying slice.
+// Size returns the len of the vector's underlying slice.
 // This is not titled Len because it conflicts the package's
 // convention of calling the Norm the Len.
 func (vn *VecN) Size() int {
 	return len(vn.vec)
 }
 
-// Returns the cap of the vector's underlying slice.
+// Cap returns the cap of the vector's underlying slice.
 func (vn *VecN) Cap() int {
 	return cap(vn.vec)
 }
@@ -134,7 +134,7 @@ func (vn *VecN) Zero(n int) {
 	}
 }
 
-// Adds vn and addend, storing the result in dst.
+// Add adds vn and addend, storing the result in dst.
 // If dst does not have sufficient size it will be resized
 // Dst may be one of the other arguments. If dst is nil, it will be allocated.
 // The value returned is dst, for easier method chaining
@@ -176,7 +176,7 @@ func (vn *VecN) Sub(dst *VecN, addend *VecN) *VecN {
 	return dst
 }
 
-// Takes the binary cross product of vn and other, and stores it in dst.
+// Cross takes the binary cross product of vn and other, and stores it in dst.
 // If either vn or other are not of size 3 this function will panic
 //
 // If dst is not of sufficient size, or is nil, a new slice is allocated.

--- a/mgl32/vector.go
+++ b/mgl32/vector.go
@@ -148,7 +148,7 @@ func (v1 Vec2) ApproxEqual(v2 Vec2) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses it to do an
 // element-wise comparison of the vector to another.
 func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float32) bool {
 	for i := range v1 {
@@ -159,7 +159,7 @@ func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float32) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec2) ApproxFuncEqual(v2 Vec2, eq func(float32, float32) bool) bool {
 	for i := range v1 {
@@ -186,7 +186,7 @@ func (v Vec2) Y() float32 {
 	return v[1]
 }
 
-// Does the vector outer product
+// OuterProd2 Does the vector outer product
 // of two vectors. The outer product produces an
 // 2x2 matrix. E.G. a Vec2 * Vec2 = Mat2.
 //
@@ -201,7 +201,7 @@ func (v1 Vec2) OuterProd2(v2 Vec2) Mat2 {
 	return Mat2{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 Does the vector outer product
 // of two vectors. The outer product produces an
 // 2x3 matrix. E.G. a Vec2 * Vec3 = Mat2x3.
 //
@@ -216,7 +216,7 @@ func (v1 Vec2) OuterProd3(v2 Vec3) Mat2x3 {
 	return Mat2x3{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[0] * v2[2], v1[1] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 Does the vector outer product
 // of two vectors. The outer product produces an
 // 2x4 matrix. E.G. a Vec2 * Vec4 = Mat2x4.
 //
@@ -301,7 +301,7 @@ func (v1 Vec3) ApproxEqual(v2 Vec3) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses it to do an
 // element-wise comparison of the vector to another.
 func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float32) bool {
 	for i := range v1 {
@@ -312,7 +312,7 @@ func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float32) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec3) ApproxFuncEqual(v2 Vec3, eq func(float32, float32) bool) bool {
 	for i := range v1 {
@@ -347,7 +347,7 @@ func (v Vec3) Z() float32 {
 	return v[2]
 }
 
-// Does the vector outer product
+// OuterProd2 Does the vector outer product
 // of two vectors. The outer product produces an
 // 3x2 matrix. E.G. a Vec3 * Vec2 = Mat3x2.
 //
@@ -362,7 +362,7 @@ func (v1 Vec3) OuterProd2(v2 Vec2) Mat3x2 {
 	return Mat3x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 Does the vector outer product
 // of two vectors. The outer product produces an
 // 3x3 matrix. E.G. a Vec3 * Vec3 = Mat3.
 //
@@ -377,7 +377,7 @@ func (v1 Vec3) OuterProd3(v2 Vec3) Mat3 {
 	return Mat3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 Does the vector outer product
 // of two vectors. The outer product produces an
 // 3x4 matrix. E.G. a Vec3 * Vec4 = Mat3x4.
 //
@@ -462,7 +462,7 @@ func (v1 Vec4) ApproxEqual(v2 Vec4) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses it to do an
 // element-wise comparison of the vector to another.
 func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float32) bool {
 	for i := range v1 {
@@ -473,7 +473,7 @@ func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float32) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec4) ApproxFuncEqual(v2 Vec4, eq func(float32, float32) bool) bool {
 	for i := range v1 {
@@ -516,7 +516,7 @@ func (v Vec4) W() float32 {
 	return v[3]
 }
 
-// Does the vector outer product
+// OuterProd2 Does the vector outer product
 // of two vectors. The outer product produces an
 // 4x2 matrix. E.G. a Vec4 * Vec2 = Mat4x2.
 //
@@ -531,7 +531,7 @@ func (v1 Vec4) OuterProd2(v2 Vec2) Mat4x2 {
 	return Mat4x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 Does the vector outer product
 // of two vectors. The outer product produces an
 // 4x3 matrix. E.G. a Vec4 * Vec3 = Mat4x3.
 //
@@ -546,7 +546,7 @@ func (v1 Vec4) OuterProd3(v2 Vec3) Mat4x3 {
 	return Mat4x3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2], v1[3] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 Does the vector outer product
 // of two vectors. The outer product produces an
 // 4x4 matrix. E.G. a Vec4 * Vec4 = Mat4.
 //

--- a/mgl64/matmn.go
+++ b/mgl64/matmn.go
@@ -38,7 +38,7 @@ func NewMatrix(m, n int) (mat *MatMxN) {
 	}
 }
 
-// Returns a matrix with data specified by the data in src
+// NewMatrixFromData returns a matrix with data specified by the data in src
 //
 // For instance, to create a 3x3 MatMN from a Mat3
 //
@@ -204,7 +204,7 @@ func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
 	}
 }
 
-// Returns the trace of a square matrix (sum of all diagonal elements). If the matrix
+// Trace returns the trace of a square matrix (sum of all diagonal elements). If the matrix
 // is nil, or not square, the result will be NaN.
 func (mat *MatMxN) Trace() float64 {
 	if mat == nil || mat.m != mat.n {
@@ -219,7 +219,7 @@ func (mat *MatMxN) Trace() float64 {
 	return out
 }
 
-// Takes the transpose of mat and puts it in dst.
+// Transpose takes the transpose of mat and puts it in dst.
 //
 // If dst is not of the correct dimensions, it will be Reshaped,
 // if dst and mat are the same, a temporary matrix of the correct size will
@@ -261,7 +261,7 @@ func (mat *MatMxN) Transpose(dst *MatMxN) (t *MatMxN) {
 	return dst
 }
 
-// Returns the raw slice backing this matrix
+// Raw returns the raw slice backing this matrix
 func (mat *MatMxN) Raw() []float64 {
 	if mat == nil {
 		return nil
@@ -270,23 +270,23 @@ func (mat *MatMxN) Raw() []float64 {
 	return mat.dat
 }
 
-// Returns the number of rows in this matrix
+// NumRows returns the number of rows in this matrix
 func (mat *MatMxN) NumRows() int {
 	return mat.m
 }
 
-// Returns the number of columns in this matrix
+// NumCols returns the number of columns in this matrix
 func (mat *MatMxN) NumCols() int {
 	return mat.n
 }
 
-// Returns the number of rows and columns in this matrix
+// NumRowCols returns the number of rows and columns in this matrix
 // as a single operation
 func (mat *MatMxN) NumRowCols() (rows, cols int) {
 	return mat.m, mat.n
 }
 
-// Returns the element at the given row and column.
+// At returns the element at the given row and column.
 // This is garbage in/garbage out and does no bounds
 // checking. If the computation happens to lead to an invalid
 // element, it will be returned; or it may panic.

--- a/mgl64/matrix.go
+++ b/mgl64/matrix.go
@@ -266,7 +266,7 @@ func (m1 Mat2) ApproxEqualThreshold(m2 Mat2, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2) ApproxFuncEqual(m2 Mat2, eq func(float64, float64) bool) bool {
@@ -490,7 +490,7 @@ func (m1 Mat2x3) ApproxEqualThreshold(m2 Mat2x3, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x3) ApproxFuncEqual(m2 Mat2x3, eq func(float64, float64) bool) bool {
@@ -708,7 +708,7 @@ func (m1 Mat2x4) ApproxEqualThreshold(m2 Mat2x4, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x4) ApproxFuncEqual(m2 Mat2x4, eq func(float64, float64) bool) bool {
@@ -936,7 +936,7 @@ func (m1 Mat3x2) ApproxEqualThreshold(m2 Mat3x2, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x2) ApproxFuncEqual(m2 Mat3x2, eq func(float64, float64) bool) bool {
@@ -1229,7 +1229,7 @@ func (m1 Mat3) ApproxEqualThreshold(m2 Mat3, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3) ApproxFuncEqual(m2 Mat3, eq func(float64, float64) bool) bool {
@@ -1463,7 +1463,7 @@ func (m1 Mat3x4) ApproxEqualThreshold(m2 Mat3x4, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x4) ApproxFuncEqual(m2 Mat3x4, eq func(float64, float64) bool) bool {
@@ -1701,7 +1701,7 @@ func (m1 Mat4x2) ApproxEqualThreshold(m2 Mat4x2, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x2) ApproxFuncEqual(m2 Mat4x2, eq func(float64, float64) bool) bool {
@@ -1939,7 +1939,7 @@ func (m1 Mat4x3) ApproxEqualThreshold(m2 Mat4x3, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x3) ApproxFuncEqual(m2 Mat4x3, eq func(float64, float64) bool) bool {
@@ -2249,7 +2249,7 @@ func (m1 Mat4) ApproxEqualThreshold(m2 Mat4, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4) ApproxFuncEqual(m2 Mat4, eq func(float64, float64) bool) bool {

--- a/mgl64/matstack/matstack.go
+++ b/mgl64/matstack/matstack.go
@@ -22,7 +22,7 @@ func (ms *MatStack) Push() {
 	(*ms) = append(*ms, (*ms)[len(*ms)-1])
 }
 
-// Removes the first element of the matrix from the stack, if there is only one element left
+// Pop removes the first element of the matrix from the stack, if there is only one element left
 // there is an error.
 func (ms *MatStack) Pop() error {
 	if len(*ms) == 1 {
@@ -45,7 +45,7 @@ func (ms *MatStack) LeftMul(m mgl64.Mat4) {
 	(*ms)[len(*ms)-1] = m.Mul4((*ms)[len(*ms)-1])
 }
 
-// Returns the top element.
+// Peek returns the top element.
 func (ms *MatStack) Peek() mgl64.Mat4 {
 	return (*ms)[len(*ms)-1]
 }

--- a/mgl64/matstack/transformStack.go
+++ b/mgl64/matstack/transformStack.go
@@ -18,7 +18,7 @@ import (
 // had been made in the middle.
 type TransformStack []mgl64.Mat4
 
-// Returns a matrix stack where the top element is the identity.
+// NewTransformStack returns a matrix stack where the top element is the identity.
 func NewTransformStack() *TransformStack {
 	ms := make(TransformStack, 1)
 	ms[0] = mgl64.Ident4()
@@ -47,13 +47,13 @@ func (ms *TransformStack) Pop() (mgl64.Mat4, error) {
 	return retVal, nil
 }
 
-// Returns the value of the current top element of the stack, without
+// Peek returns the value of the current top element of the stack, without
 // removing it.
 func (ms *TransformStack) Peek() mgl64.Mat4 {
 	return (*ms)[len(*ms)-1]
 }
 
-// Returns the size of the matrix stack. This value will never be less
+// Len returns the size of the matrix stack. This value will never be less
 // than 1.
 func (ms *TransformStack) Len() int {
 	return len(*ms)

--- a/mgl64/quat.go
+++ b/mgl64/quat.go
@@ -76,7 +76,7 @@ func (q Quat) Z() float64 {
 	return q.V[2]
 }
 
-// Adds two quaternions. It's no more complicated than
+// Add adds two quaternions. It's no more complicated than
 // adding their W and V components.
 func (q1 Quat) Add(q2 Quat) Quat {
 	return Quat{q1.W + q2.W, q1.V.Add(q2.V)}
@@ -100,13 +100,13 @@ func (q1 Quat) Scale(c float64) Quat {
 	return Quat{q1.W * c, Vec3{q1.V[0] * c, q1.V[1] * c, q1.V[2] * c}}
 }
 
-// Returns the conjugate of a quaternion. Equivalent to
+// Conjugate returns the conjugate of a quaternion. Equivalent to
 // Quat{q1.W, q1.V.Mul(-1)}
 func (q1 Quat) Conjugate() Quat {
 	return Quat{q1.W, q1.V.Mul(-1)}
 }
 
-// Returns the Length of the quaternion, also known as its Norm. This is the same thing as
+// Len returns the Length of the quaternion, also known as its Norm. This is the same thing as
 // the Len of a Vec4
 func (q1 Quat) Len() float64 {
 	return float64(math.Sqrt(float64(q1.W*q1.W + q1.V[0]*q1.V[0] + q1.V[1]*q1.V[1] + q1.V[2]*q1.V[2])))
@@ -161,7 +161,7 @@ func (q1 Quat) Rotate(v Vec3) Vec3 {
 	return v.Add(cross.Mul(2 * q1.W)).Add(q1.V.Mul(2).Cross(cross))
 }
 
-// Returns the homogeneous 3D rotation matrix corresponding to the quaternion.
+// Mat4 returns the homogeneous 3D rotation matrix corresponding to the quaternion.
 func (q1 Quat) Mat4() Mat4 {
 	w, x, y, z := q1.W, q1.V[0], q1.V[1], q1.V[2]
 	return Mat4{
@@ -177,25 +177,25 @@ func (q1 Quat) Dot(q2 Quat) float64 {
 	return q1.W*q2.W + q1.V[0]*q2.V[0] + q1.V[1]*q2.V[1] + q1.V[2]*q2.V[2]
 }
 
-// Returns whether the quaternions are approximately equal, as if
+// ApproxEqual returns whether the quaternions are approximately equal, as if
 // FloatEqual was called on each matching element
 func (q1 Quat) ApproxEqual(q2 Quat) bool {
 	return FloatEqual(q1.W, q2.W) && q1.V.ApproxEqual(q2.V)
 }
 
-// Returns whether the quaternions are approximately equal with a given tolerence, as if
+// ApproxEqualThreshold returns whether the quaternions are approximately equal with a given tolerence, as if
 // FloatEqualThreshold was called on each matching element with the given epsilon
 func (q1 Quat) ApproxEqualThreshold(q2 Quat, epsilon float64) bool {
 	return FloatEqualThreshold(q1.W, q2.W, epsilon) && q1.V.ApproxEqualThreshold(q2.V, epsilon)
 }
 
-// Returns whether the quaternions are approximately equal using the given comparison function, as if
+// ApproxEqualFunc returns whether the quaternions are approximately equal using the given comparison function, as if
 // the function had been called on each individual element
 func (q1 Quat) ApproxEqualFunc(q2 Quat, f func(float64, float64) bool) bool {
 	return f(q1.W, q2.W) && q1.V.ApproxFuncEqual(q2.V, f)
 }
 
-// Returns whether the quaternions represents the same orientation
+// OrientationEqual returns whether the quaternions represents the same orientation
 //
 // Different values can represent the same orientation (q == -q) because quaternions avoid singularities
 // and discontinuities involved with rotation in 3 dimensions by adding extra dimensions
@@ -203,7 +203,7 @@ func (q1 Quat) OrientationEqual(q2 Quat) bool {
 	return q1.OrientationEqualThreshold(q2, Epsilon)
 }
 
-// Returns whether the quaternions represents the same orientation with a given tolerence
+// OrientationEqualThreshold returns whether the quaternions represents the same orientation with a given tolerence
 func (q1 Quat) OrientationEqualThreshold(q2 Quat, epsilon float64) bool {
 	return Abs(q1.Normalize().Dot(q2.Normalize())) > 1-epsilon
 }

--- a/mgl64/shapes.go
+++ b/mgl64/shapes.go
@@ -96,7 +96,7 @@ func CubicBezierCurve3D(t float64, cPoint1, cPoint2, cPoint3, cPoint4 Vec3) Vec3
 	return cPoint1.Mul((1 - t) * (1 - t) * (1 - t)).Add(cPoint2.Mul(3 * (1 - t) * (1 - t) * t)).Add(cPoint3.Mul(3 * (1 - t) * t * t)).Add(cPoint4.Mul(t * t * t))
 }
 
-// Returns the point at point t along an n-control point Bezier curve
+// BezierCurve2D returns the point at point t along an n-control point Bezier curve
 //
 // t must be in the range 0.0 and 1.0 or this function will panic. Consider [0.0,1.0] to be similar to a percentage,
 // 0.0 is first control point, and the point at 1.0 is the last control point. Any point in between is how far along the path you are between 0 and 1.
@@ -214,7 +214,7 @@ func BezierSurface(u, v float64, cPoints [][]Vec3) Vec3 {
 	return point
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
+// BezierSplineInterpolate2D Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
 // though the spline may be disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic
@@ -232,7 +232,7 @@ func BezierSplineInterpolate2D(t float64, ranges [][2]float64, cPoints [][]Vec2)
 	panic("t is out of the range of all bezier curves in this spline")
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
+// BezierSplineInterpolate3D Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
 // though the spline may be disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic

--- a/mgl64/util.go
+++ b/mgl64/util.go
@@ -109,7 +109,7 @@ func ClampFunc(low, high float64) func(float64) float64 {
 /* The IsClamped functions use strict equality (meaning: not the FloatEqual function)
 there shouldn't be any major issues with this since clamp is often used to fix minor errors*/
 
-// Checks if a is clamped between low and high as if
+// IsClamped checks if a is clamped between low and high as if
 // Clamp(a, low, high) had been called.
 //
 // In most cases it's probably better to just call Clamp

--- a/mgl64/vecn.go
+++ b/mgl64/vecn.go
@@ -51,7 +51,7 @@ func NewVecN(n int) *VecN {
 	}
 }
 
-// Returns the raw slice backing the VecN
+// Raw returns the raw slice backing the VecN
 //
 // This may be sent back to the memory pool at any time
 // and you aren't advised to rely on this value
@@ -59,7 +59,7 @@ func (vn VecN) Raw() []float64 {
 	return vn.vec
 }
 
-// Gets the element at index i from the vector.
+// Get gets the element at index i from the vector.
 // This does not bounds check, and will panic if i is
 // out of range.
 func (vn VecN) Get(i int) float64 {
@@ -115,14 +115,14 @@ func (vn *VecN) SetBackingSlice(newSlice []float64) {
 	vn.vec = newSlice
 }
 
-// Return the len of the vector's underlying slice.
+// Size returns the len of the vector's underlying slice.
 // This is not titled Len because it conflicts the package's
 // convention of calling the Norm the Len.
 func (vn *VecN) Size() int {
 	return len(vn.vec)
 }
 
-// Returns the cap of the vector's underlying slice.
+// Cap returns the cap of the vector's underlying slice.
 func (vn *VecN) Cap() int {
 	return cap(vn.vec)
 }
@@ -136,7 +136,7 @@ func (vn *VecN) Zero(n int) {
 	}
 }
 
-// Adds vn and addend, storing the result in dst.
+// Add adds vn and addend, storing the result in dst.
 // If dst does not have sufficient size it will be resized
 // Dst may be one of the other arguments. If dst is nil, it will be allocated.
 // The value returned is dst, for easier method chaining
@@ -178,7 +178,7 @@ func (vn *VecN) Sub(dst *VecN, addend *VecN) *VecN {
 	return dst
 }
 
-// Takes the binary cross product of vn and other, and stores it in dst.
+// Cross takes the binary cross product of vn and other, and stores it in dst.
 // If either vn or other are not of size 3 this function will panic
 //
 // If dst is not of sufficient size, or is nil, a new slice is allocated.

--- a/mgl64/vector.go
+++ b/mgl64/vector.go
@@ -151,7 +151,7 @@ func (v1 Vec2) ApproxEqual(v2 Vec2) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses it to do an
 // element-wise comparison of the vector to another.
 func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float64) bool {
 	for i := range v1 {
@@ -162,7 +162,7 @@ func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float64) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec2) ApproxFuncEqual(v2 Vec2, eq func(float64, float64) bool) bool {
 	for i := range v1 {
@@ -189,7 +189,7 @@ func (v Vec2) Y() float64 {
 	return v[1]
 }
 
-// Does the vector outer product
+// OuterProd2 Does the vector outer product
 // of two vectors. The outer product produces an
 // 2x2 matrix. E.G. a Vec2 * Vec2 = Mat2.
 //
@@ -204,7 +204,7 @@ func (v1 Vec2) OuterProd2(v2 Vec2) Mat2 {
 	return Mat2{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 Does the vector outer product
 // of two vectors. The outer product produces an
 // 2x3 matrix. E.G. a Vec2 * Vec3 = Mat2x3.
 //
@@ -219,7 +219,7 @@ func (v1 Vec2) OuterProd3(v2 Vec3) Mat2x3 {
 	return Mat2x3{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[0] * v2[2], v1[1] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 Does the vector outer product
 // of two vectors. The outer product produces an
 // 2x4 matrix. E.G. a Vec2 * Vec4 = Mat2x4.
 //
@@ -304,7 +304,7 @@ func (v1 Vec3) ApproxEqual(v2 Vec3) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses it to do an
 // element-wise comparison of the vector to another.
 func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float64) bool {
 	for i := range v1 {
@@ -315,7 +315,7 @@ func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float64) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec3) ApproxFuncEqual(v2 Vec3, eq func(float64, float64) bool) bool {
 	for i := range v1 {
@@ -350,7 +350,7 @@ func (v Vec3) Z() float64 {
 	return v[2]
 }
 
-// Does the vector outer product
+// OuterProd2 Does the vector outer product
 // of two vectors. The outer product produces an
 // 3x2 matrix. E.G. a Vec3 * Vec2 = Mat3x2.
 //
@@ -365,7 +365,7 @@ func (v1 Vec3) OuterProd2(v2 Vec2) Mat3x2 {
 	return Mat3x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 Does the vector outer product
 // of two vectors. The outer product produces an
 // 3x3 matrix. E.G. a Vec3 * Vec3 = Mat3.
 //
@@ -380,7 +380,7 @@ func (v1 Vec3) OuterProd3(v2 Vec3) Mat3 {
 	return Mat3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 Does the vector outer product
 // of two vectors. The outer product produces an
 // 3x4 matrix. E.G. a Vec3 * Vec4 = Mat3x4.
 //
@@ -465,7 +465,7 @@ func (v1 Vec4) ApproxEqual(v2 Vec4) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses it to do an
 // element-wise comparison of the vector to another.
 func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float64) bool {
 	for i := range v1 {
@@ -476,7 +476,7 @@ func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float64) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec4) ApproxFuncEqual(v2 Vec4, eq func(float64, float64) bool) bool {
 	for i := range v1 {
@@ -519,7 +519,7 @@ func (v Vec4) W() float64 {
 	return v[3]
 }
 
-// Does the vector outer product
+// OuterProd2 Does the vector outer product
 // of two vectors. The outer product produces an
 // 4x2 matrix. E.G. a Vec4 * Vec2 = Mat4x2.
 //
@@ -534,7 +534,7 @@ func (v1 Vec4) OuterProd2(v2 Vec2) Mat4x2 {
 	return Mat4x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 Does the vector outer product
 // of two vectors. The outer product produces an
 // 4x3 matrix. E.G. a Vec4 * Vec3 = Mat4x3.
 //
@@ -549,7 +549,7 @@ func (v1 Vec4) OuterProd3(v2 Vec3) Mat4x3 {
 	return Mat4x3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2], v1[3] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 Does the vector outer product
 // of two vectors. The outer product produces an
 // 4x4 matrix. E.G. a Vec4 * Vec4 = Mat4.
 //


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?