### PR TITLE
Update Travis to run with supported Go versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-  - 1.10.0
-  - 1.6.2
+  - 1.11.8
+  - 1.12.3
   - tip
 matrix:
   allow_failures:
@@ -13,5 +13,4 @@ install:
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
-  - go tool vet .
   - go test -v -race ./...


### PR DESCRIPTION
Also, drop `go tool vet` which isn't supported anymore, and is also incorporated in `go test`.

~This PR will also include the content of #75 once travis is passing, with the fixes requested by @dmitshur.~ Edit: see that PR, those changes were incorrect so I'm merging this indepdendently.