### PR TITLE
Fix docstrings to match effective Go convention

### DIFF
--- a/mgl32/conv.go
+++ b/mgl32/conv.go
@@ -8,7 +8,7 @@ import (
 	"math"
 )
 
-// Converts 3-dimensional cartesian coordinates (x,y,z) to spherical
+// CartesianToSpherical converts 3-dimensional cartesian coordinates (x,y,z) to spherical
 // coordinates with radius r, inclination theta, and azimuth phi.
 //
 // All angles are in radians.
@@ -20,8 +20,8 @@ func CartesianToSpherical(coord Vec3) (r, theta, phi float32) {
 	return
 }
 
-// Converts 3-dimensional cartesian coordinates (x,y,z) to cylindrical
-// coordinates with radial distance r, azimuth phi, and height z.
+// CartesianToCylindical converts 3-dimensional cartesian coordinates (x,y,z) to
+// cylindrical coordinates with radial distance r, azimuth phi, and height z.
 //
 // All angles are in radians.
 func CartesianToCylindical(coord Vec3) (rho, phi, z float32) {
@@ -34,7 +34,7 @@ func CartesianToCylindical(coord Vec3) (rho, phi, z float32) {
 	return
 }
 
-// Converts spherical coordinates with radius r, inclination theta,
+// SphericalToCartesian converts spherical coordinates with radius r, inclination theta,
 // and azimuth phi to cartesian coordinates (x,y,z).
 //
 // Angles are in radians.
@@ -45,9 +45,9 @@ func SphericalToCartesian(r, theta, phi float32) Vec3 {
 	return Vec3{r * float32(st*cp), r * float32(st*sp), r * float32(ct)}
 }
 
-// Converts spherical coordinates with radius r, inclination theta,
-// and azimuth phi to cylindrical coordinates with radial distance r,
-// azimuth phi, and height z.
+// SphericalToCylindrical converts spherical coordinates with radius r,
+// inclination theta, and azimuth phi to cylindrical coordinates with radial
+// distance r, azimuth phi, and height z.
 //
 // Angles are in radians
 func SphericalToCylindrical(r, theta, phi float32) (rho, phi2, z float32) {
@@ -60,8 +60,8 @@ func SphericalToCylindrical(r, theta, phi float32) (rho, phi2, z float32) {
 	return
 }
 
-// Converts cylindrical coordinates with radial distance r,
-// azimuth phi, and height z to spherical coordinates with radius r,
+// CylindircalToSpherical converts cylindrical coordinates with radial distance
+// r, azimuth phi, and height z to spherical coordinates with radius r,
 // inclination theta, and azimuth phi.
 //
 // Angles are in radians
@@ -73,8 +73,8 @@ func CylindircalToSpherical(rho, phi, z float32) (r, theta, phi2 float32) {
 	return
 }
 
-// Converts cylindrical coordinates with radial distance r,
-// azimuth phi, and height z to cartesian coordinates (x,y,z)
+// CylindricalToCartesian converts cylindrical coordinates with radial distance
+// r, azimuth phi, and height z to cartesian coordinates (x,y,z)
 //
 // Angles are in radians.
 func CylindricalToCartesian(rho, phi, z float32) Vec3 {
@@ -83,12 +83,12 @@ func CylindricalToCartesian(rho, phi, z float32) Vec3 {
 	return Vec3{rho * float32(c), rho * float32(s), z}
 }
 
-// Converts degrees to radians
+// DegToRad converts degrees to radians
 func DegToRad(angle float32) float32 {
 	return angle * float32(math.Pi) / 180
 }
 
-// Converts radians to degrees
+// RadToDeg converts radians to degrees
 func RadToDeg(angle float32) float32 {
 	return angle * 180 / float32(math.Pi)
 }

--- a/mgl32/matmn.go
+++ b/mgl32/matmn.go
@@ -8,7 +8,7 @@ import (
 	"math"
 )
 
-// An arbitrary mxn matrix backed by a slice of floats.
+// MatMxN is an arbitrary mxn matrix backed by a slice of floats.
 //
 // This is emphatically not recommended for hardcore n-dimensional
 // linear algebra. For that purpose I recommend github.com/gonum/matrix or
@@ -27,7 +27,7 @@ type MatMxN struct {
 	dat  []float32
 }
 
-// Creates a matrix backed by a new slice of size m*n
+// NewMatrix creates a matrix backed by a new slice of size m*n
 func NewMatrix(m, n int) (mat *MatMxN) {
 	if shouldPool {
 		return &MatMxN{m: m, n: n, dat: grabFromPool(m * n)}
@@ -36,16 +36,15 @@ func NewMatrix(m, n int) (mat *MatMxN) {
 	}
 }
 
-// Returns a matrix with data specified by the data in src
+// NewMatrixFromData returns a matrix with data specified by the data in src
 //
 // For instance, to create a 3x3 MatMN from a Mat3
 //
 //    m1 := mgl32.Rotate3DX(3.14159)
 //    mat := mgl32.NewBackedMatrix(m1[:],3,3)
 //
-// will create an MN matrix matching the data in the original
-// rotation matrix. This matrix is NOT backed by the initial slice;
-// it's a copy of the data
+// will create an MN matrix matching the data in the original rotation matrix.
+// This matrix is NOT backed by the initial slice; it's a copy of the data
 //
 // If m*n > cap(src), this function will panic.
 func NewMatrixFromData(src []float32, m, n int) *MatMxN {
@@ -60,7 +59,7 @@ func NewMatrixFromData(src []float32, m, n int) *MatMxN {
 	return &MatMxN{m: m, n: n, dat: internal}
 }
 
-// Copies src into dst. This Reshapes dst
+// CopyMatMN copies src into dst. This Reshapes dst
 // to the same size as src.
 //
 // If dst or src is nil, this is a no-op
@@ -72,7 +71,7 @@ func CopyMatMN(dst, src *MatMxN) {
 	copy(dst.dat, src.dat)
 }
 
-// Stores the NxN identity matrix in dst, reallocating as necessary.
+// IdentN stores the NxN identity matrix in dst, reallocating as necessary.
 func IdentN(dst *MatMxN, n int) *MatMxN {
 	dst = dst.Reshape(n, n)
 
@@ -89,11 +88,12 @@ func IdentN(dst *MatMxN, n int) *MatMxN {
 	return dst
 }
 
-// Creates an NxN diagonal matrix seeded by the diagonal vector
-// diag. Meaning: for all entries, where i==j, dst.At(i,j) = diag[i]. Otherwise
+// DiagN creates an NxN diagonal matrix seeded by the diagonal vector diag.
+// Meaning: for all entries, where i==j, dst.At(i,j) = diag[i]. Otherwise
 // dst.At(i,j) = 0
 //
-// This reshapes dst to the correct size, returning/grabbing from the memory pool as necessary.
+// This reshapes dst to the correct size, returning/grabbing from the memory
+// pool as necessary.
 func DiagN(dst *MatMxN, diag *VecN) *MatMxN {
 	dst = dst.Reshape(len(diag.vec), len(diag.vec))
 	n := len(diag.vec)
@@ -111,7 +111,7 @@ func DiagN(dst *MatMxN, diag *VecN) *MatMxN {
 	return dst
 }
 
-// Reshapes the matrix to m by n and zeroes out all
+// Zero reshapes the matrix to m by n and zeroes out all
 // elements.
 func (mat *MatMxN) Zero(m, n int) {
 	if mat == nil {
@@ -124,7 +124,7 @@ func (mat *MatMxN) Zero(m, n int) {
 	}
 }
 
-// Returns the underlying matrix slice to the memory pool
+// destroy returns the underlying matrix slice to the memory pool
 func (mat *MatMxN) destroy() {
 	if mat == nil {
 		return
@@ -137,7 +137,7 @@ func (mat *MatMxN) destroy() {
 	mat.dat = nil
 }
 
-// Reshapes the matrix to the desired dimensions.
+// Reshape reshapes the matrix to the desired dimensions.
 // If the overall size of the new matrix (m*n) is bigger
 // than the current size, the underlying slice will
 // be grown, sending the current slice to the memory pool
@@ -169,12 +169,13 @@ func (mat *MatMxN) Reshape(m, n int) *MatMxN {
 	return mat
 }
 
-// Infers an MxN matrix from a constant matrix from this package. For instance,
-// a Mat2x3 inferred with this function will work just like NewMatrixFromData(m[:],2,3)
-// where m is the Mat2x3. This uses a type switch.
+// InferMatrix infers an MxN matrix from a constant matrix from this package.
+// For instance, a Mat2x3 inferred with this function will work just like
+// NewMatrixFromData(m[:],2,3) where m is the Mat2x3. This uses a type switch.
 //
-// I personally recommend using NewMatrixFromData, because it avoids a potentially costly type switch.
-// However, this is also more robust and less error prone if you change the size of your matrix somewhere.
+// I personally recommend using NewMatrixFromData, because it avoids a
+// potentially costly type switch. However, this is also more robust and less
+// error prone if you change the size of your matrix somewhere.
 //
 // If the value passed in is not recognized, it returns an InferMatrixError.
 func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
@@ -202,8 +203,8 @@ func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
 	}
 }
 
-// Returns the trace of a square matrix (sum of all diagonal elements). If the matrix
-// is nil, or not square, the result will be NaN.
+// Trace returns the trace of a square matrix (sum of all diagonal elements). If
+// the matrix is nil, or not square, the result will be NaN.
 func (mat *MatMxN) Trace() float32 {
 	if mat == nil || mat.m != mat.n {
 		return float32(math.NaN())
@@ -217,7 +218,7 @@ func (mat *MatMxN) Trace() float32 {
 	return out
 }
 
-// Takes the transpose of mat and puts it in dst.
+// Transpose takes the transpose of mat and puts it in dst.
 //
 // If dst is not of the correct dimensions, it will be Reshaped,
 // if dst and mat are the same, a temporary matrix of the correct size will
@@ -259,7 +260,7 @@ func (mat *MatMxN) Transpose(dst *MatMxN) (t *MatMxN) {
 	return dst
 }
 
-// Returns the raw slice backing this matrix
+// Raw returns the raw slice backing this matrix
 func (mat *MatMxN) Raw() []float32 {
 	if mat == nil {
 		return nil
@@ -268,23 +269,23 @@ func (mat *MatMxN) Raw() []float32 {
 	return mat.dat
 }
 
-// Returns the number of rows in this matrix
+// NumRows returns the number of rows in this matrix
 func (mat *MatMxN) NumRows() int {
 	return mat.m
 }
 
-// Returns the number of columns in this matrix
+// NumCols returns the number of columns in this matrix
 func (mat *MatMxN) NumCols() int {
 	return mat.n
 }
 
-// Returns the number of rows and columns in this matrix
+// NumRowCols returns the number of rows and columns in this matrix
 // as a single operation
 func (mat *MatMxN) NumRowCols() (rows, cols int) {
 	return mat.m, mat.n
 }
 
-// Returns the element at the given row and column.
+// At returns the element at the given row and column.
 // This is garbage in/garbage out and does no bounds
 // checking. If the computation happens to lead to an invalid
 // element, it will be returned; or it may panic.
@@ -292,7 +293,7 @@ func (mat *MatMxN) At(row, col int) float32 {
 	return mat.dat[col*mat.m+row]
 }
 
-// Sets the element at the given row and column.
+// Set sets the element at the given row and column.
 // This is garbage in/garbage out and does no bounds
 // checking. If the computation happens to lead to an invalid
 // element, it will be set; or it may panic.
@@ -300,6 +301,7 @@ func (mat *MatMxN) Set(row, col int, val float32) {
 	mat.dat[col*mat.m+row] = val
 }
 
+// Add is the arithemtic + operator defined on a MatMxN.
 func (mat *MatMxN) Add(dst *MatMxN, addend *MatMxN) *MatMxN {
 	if mat == nil || addend == nil || mat.m != addend.m || mat.n != addend.n {
 		return nil
@@ -316,6 +318,7 @@ func (mat *MatMxN) Add(dst *MatMxN, addend *MatMxN) *MatMxN {
 	return dst
 }
 
+// Sub is the arithemtic - operator defined on a MatMxN.
 func (mat *MatMxN) Sub(dst *MatMxN, subtrahend *MatMxN) *MatMxN {
 	if mat == nil || subtrahend == nil || mat.m != subtrahend.m || mat.n != subtrahend.n {
 		return nil
@@ -332,13 +335,14 @@ func (mat *MatMxN) Sub(dst *MatMxN, subtrahend *MatMxN) *MatMxN {
 	return dst
 }
 
-// Performs matrix multiplication on MxN matrix mat and NxO matrix mul, storing the result in dst.
-// This returns dst, or nil if the operation is not able to be performed.
+// MulMxN performs matrix multiplication on MxN matrix mat and NxO matrix mul,
+// storing the result in dst. This returns dst, or nil if the operation is not
+// able to be performed.
 //
 // If mat == dst, or mul == dst a temporary matrix will be used.
 //
-// This uses the naive algorithm (though on smaller matrices,
-// this can actually be faster; about len(mat)+len(mul) < ~100)
+// This uses the naive algorithm (though on smaller matrices, this can actually
+// be faster; about len(mat)+len(mul) < ~100)
 func (mat *MatMxN) MulMxN(dst *MatMxN, mul *MatMxN) *MatMxN {
 	if mat == nil || mul == nil || mat.n != mul.m {
 		return nil
@@ -377,7 +381,7 @@ func (mat *MatMxN) MulMxN(dst *MatMxN, mul *MatMxN) *MatMxN {
 	return dst
 }
 
-// Performs a scalar multiplication between mat and some constant c,
+// Mul performs a scalar multiplication between mat and some constant c,
 // storing the result in dst. Mat and dst can be equal. If dst is not the
 // correct size, a Reshape will occur.
 func (mat *MatMxN) Mul(dst *MatMxN, c float32) *MatMxN {
@@ -394,12 +398,12 @@ func (mat *MatMxN) Mul(dst *MatMxN, c float32) *MatMxN {
 	return dst
 }
 
-// Multiplies the matrix by a vector of size n. If mat or v is
-// nil, this returns nil. If the number of columns in mat does not match
-// the Size of v, this also returns nil.
+// MulNx1 multiplies the matrix by a vector of size n. If mat or v is nil, this
+// returns nil. If the number of columns in mat does not match the Size of v,
+// this also returns nil.
 //
-// Dst will be resized if it's not big enough. If dst == v; a temporary
-// vector will be allocated and returned via the realloc callback when complete.
+// Dst will be resized if it's not big enough. If dst == v; a temporary vector
+// will be allocated and returned via the realloc callback when complete.
 func (mat *MatMxN) MulNx1(dst, v *VecN) *VecN {
 	if mat == nil || v == nil || mat.n != len(v.vec) {
 		return nil
@@ -424,6 +428,8 @@ func (mat *MatMxN) MulNx1(dst, v *VecN) *VecN {
 	return dst
 }
 
+// ApproxEqual returns whether the two vectors are approximately equal (See
+// FloatEqual).
 func (mat *MatMxN) ApproxEqual(m2 *MatMxN) bool {
 	if mat == m2 {
 		return true
@@ -441,6 +447,8 @@ func (mat *MatMxN) ApproxEqual(m2 *MatMxN) bool {
 	return true
 }
 
+// ApproxEqualThreshold returns whether the two vectors are approximately equal
+// to within the given threshold given by "epsilon" (See ApproxEqualThreshold).
 func (mat *MatMxN) ApproxEqualThreshold(m2 *MatMxN, epsilon float32) bool {
 	if mat == m2 {
 		return true
@@ -458,6 +466,8 @@ func (mat *MatMxN) ApproxEqualThreshold(m2 *MatMxN, epsilon float32) bool {
 	return true
 }
 
+// ApproxEqualFunc returns whether the two vectors are approximately equal,
+// given a function which compares two scalar elements.
 func (mat *MatMxN) ApproxEqualFunc(m2 *MatMxN, comp func(float32, float32) bool) bool {
 	if mat == m2 {
 		return true
@@ -475,18 +485,25 @@ func (mat *MatMxN) ApproxEqualFunc(m2 *MatMxN, comp func(float32, float32) bool)
 	return true
 }
 
+// InferMatrixError may be returned by InferMatrix.
+//
+// Make sure you're using a constant matrix such as Mat3 from within the same
+// package (meaning: mgl32.MatMxN can't handle a mgl64.Mat2x3).
 type InferMatrixError struct{}
 
 func (me InferMatrixError) Error() string {
 	return "could not infer matrix. Make sure you're using a constant matrix such as Mat3 from within the same package (meaning: mgl32.MatMxN can't handle a mgl64.Mat2x3)."
 }
 
+// RectangularMatrixError is returned when a rectangular matrix was expected but
+// not given.
 type RectangularMatrixError struct{}
 
 func (mse RectangularMatrixError) Error() string {
 	return "the matrix was the wrong shape, needed a square matrix."
 }
 
+// NilMatrixError is returned when an operand to a function was unexpectedly 'nil'.
 type NilMatrixError struct{}
 
 func (me NilMatrixError) Error() string {

--- a/mgl32/matrix.go
+++ b/mgl32/matrix.go
@@ -78,12 +78,12 @@ func (m Mat4) Mat3() Mat3 {
 	)
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat2) SetRow(row int, v Vec2) {
 	m[row+0], m[row+2] = v[0], v[1]
 }
@@ -210,7 +210,7 @@ func (m1 Mat2) Transpose() Mat2 {
 	return Mat2{m1[0], m1[2], m1[1], m1[3]}
 }
 
-// The determinant of a matrix is a measure of a square matrix's
+// Det returns the determinant of a matrix. It is a measure of a square matrix's
 // singularity and invertability, among other things. In this library, the
 // determinant is hard coded based on pre-computed cofactor expansion, and uses
 // no loops. Of course, the addition and multiplication must still be done.
@@ -263,7 +263,7 @@ func (m1 Mat2) ApproxEqualThreshold(m2 Mat2, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2) ApproxFuncEqual(m2 Mat2, eq func(float32, float32) bool) bool {
@@ -357,12 +357,12 @@ func (m Mat2) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x3) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x3) SetRow(row int, v Vec3) {
 	m[row+0], m[row+2], m[row+4] = v[0], v[1], v[2]
 }
@@ -487,7 +487,7 @@ func (m1 Mat2x3) ApproxEqualThreshold(m2 Mat2x3, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x3) ApproxFuncEqual(m2 Mat2x3, eq func(float32, float32) bool) bool {
@@ -575,12 +575,12 @@ func (m Mat2x3) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x4) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x4) SetRow(row int, v Vec4) {
 	m[row+0], m[row+2], m[row+4], m[row+6] = v[0], v[1], v[2], v[3]
 }
@@ -705,7 +705,7 @@ func (m1 Mat2x4) ApproxEqualThreshold(m2 Mat2x4, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x4) ApproxFuncEqual(m2 Mat2x4, eq func(float32, float32) bool) bool {
@@ -793,12 +793,12 @@ func (m Mat2x4) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x2) SetCol(col int, v Vec3) {
 	m[col*3+0], m[col*3+1], m[col*3+2] = v[0], v[1], v[2]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x2) SetRow(row int, v Vec2) {
 	m[row+0], m[row+3] = v[0], v[1]
 }
@@ -933,7 +933,7 @@ func (m1 Mat3x2) ApproxEqualThreshold(m2 Mat3x2, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x2) ApproxFuncEqual(m2 Mat3x2, eq func(float32, float32) bool) bool {
@@ -1021,12 +1021,12 @@ func (m Mat3x2) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat3) SetCol(col int, v Vec3) {
 	m[col*3+0], m[col*3+1], m[col*3+2] = v[0], v[1], v[2]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat3) SetRow(row int, v Vec3) {
 	m[row+0], m[row+3], m[row+6] = v[0], v[1], v[2]
 }
@@ -1163,7 +1163,7 @@ func (m1 Mat3) Transpose() Mat3 {
 	return Mat3{m1[0], m1[3], m1[6], m1[1], m1[4], m1[7], m1[2], m1[5], m1[8]}
 }
 
-// The determinant of a matrix is a measure of a square matrix's
+// Det returns the determinant of a matrix. It is a measure of a square matrix's
 // singularity and invertability, among other things. In this library, the
 // determinant is hard coded based on pre-computed cofactor expansion, and uses
 // no loops. Of course, the addition and multiplication must still be done.
@@ -1226,7 +1226,7 @@ func (m1 Mat3) ApproxEqualThreshold(m2 Mat3, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3) ApproxFuncEqual(m2 Mat3, eq func(float32, float32) bool) bool {
@@ -1320,12 +1320,12 @@ func (m Mat3) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x4) SetCol(col int, v Vec3) {
 	m[col*3+0], m[col*3+1], m[col*3+2] = v[0], v[1], v[2]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x4) SetRow(row int, v Vec4) {
 	m[row+0], m[row+3], m[row+6], m[row+9] = v[0], v[1], v[2], v[3]
 }
@@ -1460,7 +1460,7 @@ func (m1 Mat3x4) ApproxEqualThreshold(m2 Mat3x4, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x4) ApproxFuncEqual(m2 Mat3x4, eq func(float32, float32) bool) bool {
@@ -1548,12 +1548,12 @@ func (m Mat3x4) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x2) SetCol(col int, v Vec4) {
 	m[col*4+0], m[col*4+1], m[col*4+2], m[col*4+3] = v[0], v[1], v[2], v[3]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x2) SetRow(row int, v Vec2) {
 	m[row+0], m[row+4] = v[0], v[1]
 }
@@ -1698,7 +1698,7 @@ func (m1 Mat4x2) ApproxEqualThreshold(m2 Mat4x2, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x2) ApproxFuncEqual(m2 Mat4x2, eq func(float32, float32) bool) bool {
@@ -1786,12 +1786,12 @@ func (m Mat4x2) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x3) SetCol(col int, v Vec4) {
 	m[col*4+0], m[col*4+1], m[col*4+2], m[col*4+3] = v[0], v[1], v[2], v[3]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x3) SetRow(row int, v Vec3) {
 	m[row+0], m[row+4], m[row+8] = v[0], v[1], v[2]
 }
@@ -1936,7 +1936,7 @@ func (m1 Mat4x3) ApproxEqualThreshold(m2 Mat4x3, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x3) ApproxFuncEqual(m2 Mat4x3, eq func(float32, float32) bool) bool {
@@ -2024,12 +2024,12 @@ func (m Mat4x3) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat4) SetCol(col int, v Vec4) {
 	m[col*4+0], m[col*4+1], m[col*4+2], m[col*4+3] = v[0], v[1], v[2], v[3]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat4) SetRow(row int, v Vec4) {
 	m[row+0], m[row+4], m[row+8], m[row+12] = v[0], v[1], v[2], v[3]
 }
@@ -2176,7 +2176,7 @@ func (m1 Mat4) Transpose() Mat4 {
 	return Mat4{m1[0], m1[4], m1[8], m1[12], m1[1], m1[5], m1[9], m1[13], m1[2], m1[6], m1[10], m1[14], m1[3], m1[7], m1[11], m1[15]}
 }
 
-// The determinant of a matrix is a measure of a square matrix's
+// Det returns the determinant of a matrix. It is a measure of a square matrix's
 // singularity and invertability, among other things. In this library, the
 // determinant is hard coded based on pre-computed cofactor expansion, and uses
 // no loops. Of course, the addition and multiplication must still be done.
@@ -2246,7 +2246,7 @@ func (m1 Mat4) ApproxEqualThreshold(m2 Mat4, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4) ApproxFuncEqual(m2 Mat4, eq func(float32, float32) bool) bool {

--- a/mgl32/matrix.tmpl
+++ b/mgl32/matrix.tmpl
@@ -83,12 +83,12 @@ func (m Mat4) Mat3() Mat3 {
 <<range $m := enum 2 3 4>><<range $n := enum 2 3 4>>
 <<$type := typename $m $n>>
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *<<$type>>) SetCol(col int, v <<typename $m 1>>) {
 	<<range $i := iter 0 $m>><<sep "," $i>>m[col*<<$m>>+<<$i>>]<<end>> = <<repeat $m "v[%d]" ",">>
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *<<$type>>) SetRow(row int, v <<typename $n 1>>) {
 	<<range $i := iter 0 $n>><<sep "," $i>>m[row+<<mul $m $i>>]<<end>> = <<repeat $n "v[%d]" ",">>
 }
@@ -178,7 +178,7 @@ func (m1 <<$type>>) Transpose() <<typename $n $m>> {
 }
 
 <<if eq $m $n>>
-// The determinant of a matrix is a measure of a square matrix's
+// Det returns the determinant of a matrix. It is a measure of a square matrix's
 // singularity and invertability, among other things. In this library, the
 // determinant is hard coded based on pre-computed cofactor expansion, and uses
 // no loops. Of course, the addition and multiplication must still be done.
@@ -271,7 +271,7 @@ func (m1 <<$type>>) ApproxEqualThreshold(m2 <<$type>>, threshold float32) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 <<$type>>) ApproxFuncEqual(m2 <<$type>>, eq func(float32, float32) bool) bool {

--- a/mgl32/matstack/matstack.go
+++ b/mgl32/matstack/matstack.go
@@ -15,13 +15,13 @@ func NewMatStack() *MatStack {
 	return &MatStack{mgl32.Ident4()}
 }
 
-// Copies the top element and pushes it on the stack.
+// Push copies the top element and pushes it on the stack.
 func (ms *MatStack) Push() {
 	(*ms) = append(*ms, (*ms)[len(*ms)-1])
 }
 
-// Removes the first element of the matrix from the stack, if there is only one element left
-// there is an error.
+// Pop removes the first element of the matrix from the stack, if there is only
+// one element left there is an error.
 func (ms *MatStack) Pop() error {
 	if len(*ms) == 1 {
 		return errors.New("Cannot pop from mat stack, at minimum stack length of 1")
@@ -31,29 +31,27 @@ func (ms *MatStack) Pop() error {
 	return nil
 }
 
-// Right multiplies the current top of the matrix by the
-// argument.
+// RightMul multiplies the current top of the matrix by the argument.
 func (ms *MatStack) RightMul(m mgl32.Mat4) {
 	(*ms)[len(*ms)-1] = (*ms)[len(*ms)-1].Mul4(m)
 }
 
-// Left multiplies the current top of the matrix by the
-// argument.
+// LeftMul multiplies the current top of the matrix by the argument.
 func (ms *MatStack) LeftMul(m mgl32.Mat4) {
 	(*ms)[len(*ms)-1] = m.Mul4((*ms)[len(*ms)-1])
 }
 
-// Returns the top element.
+// Peek returns the top element.
 func (ms *MatStack) Peek() mgl32.Mat4 {
 	return (*ms)[len(*ms)-1]
 }
 
-// Rewrites the top element of the stack with m
+// Load rewrites the top element of the stack with m
 func (ms *MatStack) Load(m mgl32.Mat4) {
 	(*ms)[len(*ms)-1] = m
 }
 
-// A shortcut for Load(mgl.Ident4())
+// LoadIdent is a shortcut for Load(mgl.Ident4())
 func (ms *MatStack) LoadIdent() {
 	(*ms)[len(*ms)-1] = mgl32.Ident4()
 }

--- a/mgl32/matstack/transformStack.go
+++ b/mgl32/matstack/transformStack.go
@@ -7,16 +7,19 @@ import (
 	"github.com/go-gl/mathgl/mgl32"
 )
 
-// A transform stack is a linear fully-persistent data structure of matrix multiplications
-// Each push to a TransformStack multiplies the current top of the stack with thew new matrix
-// and appends it to the top. Each pop undoes the previous multiplication.
+// TransformStack is a linear fully-persistent data structure of matrix
+// multiplications Each push to a TransformStack multiplies the current top of
+// the stack with thew new matrix and appends it to the top. Each pop undoes the
+// previous multiplication.
 //
-// This allows arbitrary unwinding of transformations, at the cost of a lot of memory. A notable feature
-// is the reseed and rebase, which allow invertible transformations to be rewritten as if a different transform
-// had been made in the middle.
+// This allows arbitrary unwinding of transformations, at the cost of a lot of
+// memory. A notable feature is the reseed and rebase, which allow invertible
+// transformations to be rewritten as if a different transform had been made in
+// the middle.
 type TransformStack []mgl32.Mat4
 
-// Returns a matrix stack where the top element is the identity.
+// NewTransformStack returns a matrix stack where the top element is the
+// identity.
 func NewTransformStack() *TransformStack {
 	ms := make(TransformStack, 1)
 	ms[0] = mgl32.Ident4()
@@ -24,15 +27,15 @@ func NewTransformStack() *TransformStack {
 	return &ms
 }
 
-// Multiplies the current top matrix by m, and pushes the result
-// on the stack.
+// Push multiplies the current top matrix by m, and pushes the result on the
+// stack.
 func (ms *TransformStack) Push(m mgl32.Mat4) {
 	prev := (*ms)[len(*ms)-1]
 	(*ms) = append(*ms, prev.Mul4(m))
 }
 
-// Pops the current matrix off the top of the stack and returns it.
-// If the matrix stack only has one element left, this will return an error.
+// Pop the current matrix off the top of the stack and returns it. If the matrix
+// stack only has one element left, this will return an error.
 func (ms *TransformStack) Pop() (mgl32.Mat4, error) {
 	if len(*ms) == 1 {
 		return mgl32.Mat4{}, errors.New("attempt to pop last element of the stack; Matrix Stack must have at least one element")
@@ -45,20 +48,21 @@ func (ms *TransformStack) Pop() (mgl32.Mat4, error) {
 	return retVal, nil
 }
 
-// Returns the value of the current top element of the stack, without
+// Peek returns the value of the current top element of the stack, without
 // removing it.
 func (ms *TransformStack) Peek() mgl32.Mat4 {
 	return (*ms)[len(*ms)-1]
 }
 
-// Returns the size of the matrix stack. This value will never be less
+// Len returns the size of the matrix stack. This value will never be less
 // than 1.
 func (ms *TransformStack) Len() int {
 	return len(*ms)
 }
 
-// This cuts down the matrix as if Pop had been called n times. If n would
-// bring the matrix down below 1 element, this does nothing and returns an error.
+// Unwind cuts down the matrix as if Pop had been called n times. If n would
+// bring the matrix down below 1 element, this does nothing and returns an
+// error.
 func (ms *TransformStack) Unwind(n int) error {
 	if n > len(*ms)-1 {
 		return errors.New("Cannot unwind a matrix to below 1 value")
@@ -68,9 +72,9 @@ func (ms *TransformStack) Unwind(n int) error {
 	return nil
 }
 
-// Copy will create a new "branch" of the current matrix stack,
-// the copy will contain all elements of the current stack in a new stack. Changes to
-// one will never affect the other.
+// Copy will create a new "branch" of the current matrix stack, the copy will
+// contain all elements of the current stack in a new stack. Changes to one will
+// never affect the other.
 func (ms *TransformStack) Copy() *TransformStack {
 	v := append(TransformStack{}, (*ms)...)
 	return &v

--- a/mgl32/project.go
+++ b/mgl32/project.go
@@ -9,17 +9,20 @@ import (
 	"math"
 )
 
+// Ortho generates an Ortho Matrix.
 func Ortho(left, right, bottom, top, near, far float32) Mat4 {
 	rml, tmb, fmn := (right - left), (top - bottom), (far - near)
 
 	return Mat4{float32(2. / rml), 0, 0, 0, 0, float32(2. / tmb), 0, 0, 0, 0, float32(-2. / fmn), 0, float32(-(right + left) / rml), float32(-(top + bottom) / tmb), float32(-(far + near) / fmn), 1}
 }
 
-// Equivalent to Ortho with the near and far planes being -1 and 1, respectively
+// Ortho2D is equivalent to Ortho with the near and far planes being -1 and 1,
+// respectively.
 func Ortho2D(left, right, bottom, top float32) Mat4 {
 	return Ortho(left, right, bottom, top, -1, 1)
 }
 
+// Perspective generates a Perspective Matrix.
 func Perspective(fovy, aspect, near, far float32) Mat4 {
 	// fovy = (fovy * math.Pi) / 180.0 // convert from degrees to radians
 	nmf, f := near-far, float32(1./math.Tan(float64(fovy)/2.0))
@@ -27,6 +30,7 @@ func Perspective(fovy, aspect, near, far float32) Mat4 {
 	return Mat4{float32(f / aspect), 0, 0, 0, 0, float32(f), 0, 0, 0, 0, float32((near + far) / nmf), -1, 0, 0, float32((2. * far * near) / nmf), 0}
 }
 
+// Frustum generates a Frustum Matrix.
 func Frustum(left, right, bottom, top, near, far float32) Mat4 {
 	rml, tmb, fmn := (right - left), (top - bottom), (far - near)
 	A, B, C, D := (right+left)/rml, (top+bottom)/tmb, -(far+near)/fmn, -(2*far*near)/fmn
@@ -34,11 +38,13 @@ func Frustum(left, right, bottom, top, near, far float32) Mat4 {
 	return Mat4{float32((2. * near) / rml), 0, 0, 0, 0, float32((2. * near) / tmb), 0, 0, float32(A), float32(B), float32(C), -1, 0, 0, float32(D), 0}
 }
 
+// LookAt generates a transform matrix from world space to the given eye space.
 func LookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ float32) Mat4 {
 	return LookAtV(Vec3{eyeX, eyeY, eyeZ}, Vec3{centerX, centerY, centerZ}, Vec3{upX, upY, upZ})
 }
 
-//  LookAtV generates a transform matrix from world space into the specific eye space
+// LookAtV generates a transform matrix from world space into the specific eye
+// space.
 func LookAtV(eye, center, up Vec3) Mat4 {
 	f := center.Sub(eye).Normalize()
 	s := f.Cross(up.Normalize()).Normalize()
@@ -54,10 +60,12 @@ func LookAtV(eye, center, up Vec3) Mat4 {
 	return M.Mul4(Translate3D(float32(-eye[0]), float32(-eye[1]), float32(-eye[2])))
 }
 
-// Transform a set of coordinates from object space (in obj) to window coordinates (with depth)
+// Project transforms a set of coordinates from object space (in obj) to window
+// coordinates (with depth).
 //
-// Window coordinates are continuous, not discrete (well, as continuous as an IEEE Floating Point can be), so you won't get exact pixel locations
-// without rounding or similar
+// Window coordinates are continuous, not discrete (well, as continuous as an
+// IEEE Floating Point can be), so you won't get exact pixel locations without
+// rounding or similar
 func Project(obj Vec3, modelview, projection Mat4, initialX, initialY, width, height int) (win Vec3) {
 	obj4 := obj.Vec4(1)
 
@@ -70,10 +78,13 @@ func Project(obj Vec3, modelview, projection Mat4, initialX, initialY, width, he
 	return win
 }
 
-// Transform a set of window coordinates to object space. If your MVP (projection.Mul(modelview) matrix is not invertible, this will return an error
+// UnProject transforms a set of window coordinates to object space. If your MVP
+// (projection.Mul(modelview) matrix is not invertible, this will return an
+// error.
 //
-// Note that the projection may not be perfect if you use strict pixel locations rather than the exact values given by Projectf.
-// (It's still unlikely to be perfect due to precision errors, but it will be closer)
+// Note that the projection may not be perfect if you use strict pixel locations
+// rather than the exact values given by Projectf. (It's still unlikely to be
+// perfect due to precision errors, but it will be closer)
 func UnProject(win Vec3, modelview, projection Mat4, initialX, initialY, width, height int) (obj Vec3, err error) {
 	inv := projection.Mul4(modelview).Inv()
 	var blank Mat4

--- a/mgl32/quat.go
+++ b/mgl32/quat.go
@@ -8,10 +8,12 @@ import (
 	"math"
 )
 
-// A rotation order is the order in which
-// rotations will be transformed for the purposes of AnglesToQuat
+// RotationOrder is the order in which rotations will be transformed for the
+// purposes of AnglesToQuat.
 type RotationOrder int
 
+// The RotationOrder constants represent a series of rotations along the given
+// axes for the use of AnglesToQuat.
 const (
 	XYX RotationOrder = iota
 	XYZ
@@ -27,20 +29,20 @@ const (
 	ZXY
 )
 
-// A Quaternion is an extension of the imaginary numbers; there's all sorts of
-// interesting theory behind it. In 3D graphics we mostly use it as a cheap way of
-// representing rotation since quaternions are cheaper to multiply by, and easier to
-// interpolate than matrices.
+// Quat represents a Quaternion, which is an extension of the imaginary numbers;
+// there's all sorts of interesting theory behind it. In 3D graphics we mostly
+// use it as a cheap way of representing rotation since quaternions are cheaper
+// to multiply by, and easier to interpolate than matrices.
 //
-// A Quaternion has two parts: W, the so-called scalar component,
-// and "V", the vector component. The vector component is considered to
-// be the part in 3D space, while W (loosely interpreted) is its 4D coordinate.
+// A Quaternion has two parts: W, the so-called scalar component, and "V", the
+// vector component. The vector component is considered to be the part in 3D
+// space, while W (loosely interpreted) is its 4D coordinate.
 type Quat struct {
 	W float32
 	V Vec3
 }
 
-// The quaternion identity: W=1; V=(0,0,0).
+// QuatIdent returns the quaternion identity: W=1; V=(0,0,0).
 //
 // As with all identities, multiplying any quaternion by this will yield the same
 // quaternion you started with.
@@ -48,7 +50,7 @@ func QuatIdent() Quat {
 	return Quat{1., Vec3{0, 0, 0}}
 }
 
-// Creates an angle from an axis and an angle relative to that axis.
+// QuatRotate creates an angle from an axis and an angle relative to that axis.
 //
 // This is cheaper than HomogRotate3D.
 func QuatRotate(angle float32, axis Vec3) Quat {
@@ -59,63 +61,63 @@ func QuatRotate(angle float32, axis Vec3) Quat {
 	return Quat{c, axis.Mul(s)}
 }
 
-// A convenient alias for q.V[0]
+// X is a convenient alias for q.V[0]
 func (q Quat) X() float32 {
 	return q.V[0]
 }
 
-// A convenient alias for q.V[1]
+// Y is a convenient alias for q.V[1]
 func (q Quat) Y() float32 {
 	return q.V[1]
 }
 
-// A convenient alias for q.V[2]
+// Z is a convenient alias for q.V[2]
 func (q Quat) Z() float32 {
 	return q.V[2]
 }
 
-// Adds two quaternions. It's no more complicated than
+// Add adds two quaternions. It's no more complicated than
 // adding their W and V components.
 func (q1 Quat) Add(q2 Quat) Quat {
 	return Quat{q1.W + q2.W, q1.V.Add(q2.V)}
 }
 
-// Subtracts two quaternions. It's no more complicated than
+// Sub subtracts two quaternions. It's no more complicated than
 // subtracting their W and V components.
 func (q1 Quat) Sub(q2 Quat) Quat {
 	return Quat{q1.W - q2.W, q1.V.Sub(q2.V)}
 }
 
-// Multiplies two quaternions. This can be seen as a rotation. Note that
+// Mul multiplies two quaternions. This can be seen as a rotation. Note that
 // Multiplication is NOT commutative, meaning q1.Mul(q2) does not necessarily
 // equal q2.Mul(q1).
 func (q1 Quat) Mul(q2 Quat) Quat {
 	return Quat{q1.W*q2.W - q1.V.Dot(q2.V), q1.V.Cross(q2.V).Add(q2.V.Mul(q1.W)).Add(q1.V.Mul(q2.W))}
 }
 
-// Scales every element of the quaternion by some constant factor.
+// Scale every element of the quaternion by some constant factor.
 func (q1 Quat) Scale(c float32) Quat {
 	return Quat{q1.W * c, Vec3{q1.V[0] * c, q1.V[1] * c, q1.V[2] * c}}
 }
 
-// Returns the conjugate of a quaternion. Equivalent to
-// Quat{q1.W, q1.V.Mul(-1)}
+// Conjugate returns the conjugate of a quaternion. Equivalent to
+// Quat{q1.W, q1.V.Mul(-1)}.
 func (q1 Quat) Conjugate() Quat {
 	return Quat{q1.W, q1.V.Mul(-1)}
 }
 
-// Returns the Length of the quaternion, also known as its Norm. This is the same thing as
-// the Len of a Vec4
+// Len gives the Length of the quaternion, also known as its Norm. This is the
+// same thing as the Len of a Vec4.
 func (q1 Quat) Len() float32 {
 	return float32(math.Sqrt(float64(q1.W*q1.W + q1.V[0]*q1.V[0] + q1.V[1]*q1.V[1] + q1.V[2]*q1.V[2])))
 }
 
-// Norm() is an alias for Len() since both are very common terms.
+// Norm is an alias for Len() since both are very common terms.
 func (q1 Quat) Norm() float32 {
 	return q1.Len()
 }
 
-// Normalizes the quaternion, returning its versor (unit quaternion).
+// Normalize the quaternion, returning its versor (unit quaternion).
 //
 // This is the same as normalizing it as a Vec4.
 func (q1 Quat) Normalize() Quat {
@@ -134,7 +136,7 @@ func (q1 Quat) Normalize() Quat {
 	return Quat{q1.W * 1 / length, q1.V.Mul(1 / length)}
 }
 
-// The inverse of a quaternion. The inverse is equivalent
+// Inverse of a quaternion. The inverse is equivalent
 // to the conjugate divided by the square of the length.
 //
 // This method computes the square norm by directly adding the sum
@@ -144,7 +146,7 @@ func (q1 Quat) Inverse() Quat {
 	return q1.Conjugate().Scale(1 / q1.Dot(q1))
 }
 
-// Rotates a vector by the rotation this quaternion represents.
+// Rotate a vector by the rotation this quaternion represents.
 // This will result in a 3D vector. Strictly speaking, this is
 // equivalent to q1.v.q* where the "."" is quaternion multiplication and v is interpreted
 // as a quaternion with W 0 and V v. In code:
@@ -159,7 +161,8 @@ func (q1 Quat) Rotate(v Vec3) Vec3 {
 	return v.Add(cross.Mul(2 * q1.W)).Add(q1.V.Mul(2).Cross(cross))
 }
 
-// Returns the homogeneous 3D rotation matrix corresponding to the quaternion.
+// Mat4 returns the homogeneous 3D rotation matrix corresponding to the
+// quaternion.
 func (q1 Quat) Mat4() Mat4 {
 	w, x, y, z := q1.W, q1.V[0], q1.V[1], q1.V[2]
 	return Mat4{
@@ -170,30 +173,30 @@ func (q1 Quat) Mat4() Mat4 {
 	}
 }
 
-// The dot product between two quaternions, equivalent to if this was a Vec4
+// Dot product between two quaternions, equivalent to if this was a Vec4.
 func (q1 Quat) Dot(q2 Quat) float32 {
 	return q1.W*q2.W + q1.V[0]*q2.V[0] + q1.V[1]*q2.V[1] + q1.V[2]*q2.V[2]
 }
 
-// Returns whether the quaternions are approximately equal, as if
+// ApproxEqual returns whether the quaternions are approximately equal, as if
 // FloatEqual was called on each matching element
 func (q1 Quat) ApproxEqual(q2 Quat) bool {
 	return FloatEqual(q1.W, q2.W) && q1.V.ApproxEqual(q2.V)
 }
 
-// Returns whether the quaternions are approximately equal with a given tolerence, as if
+// ApproxEqualThreshold returns whether the quaternions are approximately equal with a given tolerence, as if
 // FloatEqualThreshold was called on each matching element with the given epsilon
 func (q1 Quat) ApproxEqualThreshold(q2 Quat, epsilon float32) bool {
 	return FloatEqualThreshold(q1.W, q2.W, epsilon) && q1.V.ApproxEqualThreshold(q2.V, epsilon)
 }
 
-// Returns whether the quaternions are approximately equal using the given comparison function, as if
+// ApproxEqualFunc returns whether the quaternions are approximately equal using the given comparison function, as if
 // the function had been called on each individual element
 func (q1 Quat) ApproxEqualFunc(q2 Quat, f func(float32, float32) bool) bool {
 	return f(q1.W, q2.W) && q1.V.ApproxFuncEqual(q2.V, f)
 }
 
-// Returns whether the quaternions represents the same orientation
+// OrientationEqual returns whether the quaternions represents the same orientation
 //
 // Different values can represent the same orientation (q == -q) because quaternions avoid singularities
 // and discontinuities involved with rotation in 3 dimensions by adding extra dimensions
@@ -201,12 +204,12 @@ func (q1 Quat) OrientationEqual(q2 Quat) bool {
 	return q1.OrientationEqualThreshold(q2, Epsilon)
 }
 
-// Returns whether the quaternions represents the same orientation with a given tolerence
+// OrientationEqualThreshold returns whether the quaternions represents the same orientation with a given tolerence
 func (q1 Quat) OrientationEqualThreshold(q2 Quat, epsilon float32) bool {
 	return Abs(q1.Normalize().Dot(q2.Normalize())) > 1-epsilon
 }
 
-// Slerp is *S*pherical *L*inear Int*erp*olation, a method of interpolating
+// QuatSlerp is *S*pherical *L*inear Int*erp*olation, a method of interpolating
 // between two quaternions. This always takes the straightest path on the sphere between
 // the two quaternions, and maintains constant velocity.
 //
@@ -230,14 +233,14 @@ func QuatSlerp(q1, q2 Quat, amount float32) Quat {
 	return q1.Scale(c).Add(rel.Scale(s))
 }
 
-// *L*inear Int*erp*olation between two Quaternions, cheap and simple.
+// QuatLerp is a *L*inear Int*erp*olation between two Quaternions, cheap and simple.
 //
 // Not excessively useful, but uses can be found.
 func QuatLerp(q1, q2 Quat, amount float32) Quat {
 	return q1.Add(q2.Sub(q1).Scale(amount))
 }
 
-// *Normalized* *L*inear Int*erp*olation between two Quaternions. Cheaper than Slerp
+// QuatNlerp is a *Normalized* *L*inear Int*erp*olation between two Quaternions. Cheaper than Slerp
 // and usually just as good. This is literally Lerp with Normalize() called on it.
 //
 // Unlike Slerp, constant velocity isn't maintained, but it's much faster and
@@ -248,7 +251,7 @@ func QuatNlerp(q1, q2 Quat, amount float32) Quat {
 	return QuatLerp(q1, q2, amount).Normalize()
 }
 
-// Performs a rotation in the specified order. If the order is not
+// AnglesToQuat performs a rotation in the specified order. If the order is not
 // a valid RotationOrder, this function will panic
 //
 // The rotation "order" is more of an axis descriptor. For instance XZX would

--- a/mgl32/shapes.go
+++ b/mgl32/shapes.go
@@ -9,7 +9,7 @@ import (
 	"math"
 )
 
-// Generates a circle centered at (0,0) with a given radius.
+// Circle generates a circle centered at (0,0) with a given radius.
 // The radii are assumed to be in GL's coordinate sizing.
 //
 // Technically this draws an ellipse with two axes that match with the X and Y axes, the reason it has a radiusX and radiusY is because GL's coordinate system
@@ -43,7 +43,7 @@ func Circle(radiusX, radiusY float32, numSlices int) []Vec2 {
 	return circlePoints
 }
 
-// Generates a 2-triangle rectangle for use with GL_TRIANGLES. The width and height should use GL's proportions (that is, where a width of 1.0
+// Rect generates a 2-triangle rectangle for use with GL_TRIANGLES. The width and height should use GL's proportions (that is, where a width of 1.0
 // is equivalent to half of the width of the render target); however, the y-coordinates grow downwards, not upwards. That is, it
 // assumes you want the origin of the rectangle with the top-left corner at (0.0,0.0).
 //
@@ -62,6 +62,7 @@ func Rect(width, height float32) []Vec2 {
 	}
 }
 
+// QuadraticBezierCurve2D interpolates the point t on the given bezier curve.
 func QuadraticBezierCurve2D(t float32, cPoint1, cPoint2, cPoint3 Vec2) Vec2 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -70,6 +71,7 @@ func QuadraticBezierCurve2D(t float32, cPoint1, cPoint2, cPoint3 Vec2) Vec2 {
 	return cPoint1.Mul((1.0 - t) * (1.0 - t)).Add(cPoint2.Mul(2 * (1 - t) * t)).Add(cPoint3.Mul(t * t))
 }
 
+// QuadraticBezierCurve3D interpolates the point t on the given bezier curve.
 func QuadraticBezierCurve3D(t float32, cPoint1, cPoint2, cPoint3 Vec3) Vec3 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -78,6 +80,7 @@ func QuadraticBezierCurve3D(t float32, cPoint1, cPoint2, cPoint3 Vec3) Vec3 {
 	return cPoint1.Mul((1.0 - t) * (1.0 - t)).Add(cPoint2.Mul(2 * (1 - t) * t)).Add(cPoint3.Mul(t * t))
 }
 
+// CubicBezierCurve2D interpolates the point t on the given bezier curve.
 func CubicBezierCurve2D(t float32, cPoint1, cPoint2, cPoint3, cPoint4 Vec2) Vec2 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -86,6 +89,7 @@ func CubicBezierCurve2D(t float32, cPoint1, cPoint2, cPoint3, cPoint4 Vec2) Vec2
 	return cPoint1.Mul((1 - t) * (1 - t) * (1 - t)).Add(cPoint2.Mul(3 * (1 - t) * (1 - t) * t)).Add(cPoint3.Mul(3 * (1 - t) * t * t)).Add(cPoint4.Mul(t * t * t))
 }
 
+// CubicBezierCurve3D interpolates the point t on the given bezier curve.
 func CubicBezierCurve3D(t float32, cPoint1, cPoint2, cPoint3, cPoint4 Vec3) Vec3 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -94,7 +98,7 @@ func CubicBezierCurve3D(t float32, cPoint1, cPoint2, cPoint3, cPoint4 Vec3) Vec3
 	return cPoint1.Mul((1 - t) * (1 - t) * (1 - t)).Add(cPoint2.Mul(3 * (1 - t) * (1 - t) * t)).Add(cPoint3.Mul(3 * (1 - t) * t * t)).Add(cPoint4.Mul(t * t * t))
 }
 
-// Returns the point at point t along an n-control point Bezier curve
+// BezierCurve2D returns the point at point t along an n-control point Bezier curve
 //
 // t must be in the range 0.0 and 1.0 or this function will panic. Consider [0.0,1.0] to be similar to a percentage,
 // 0.0 is first control point, and the point at 1.0 is the last control point. Any point in between is how far along the path you are between 0 and 1.
@@ -116,7 +120,7 @@ func BezierCurve2D(t float32, cPoints []Vec2) Vec2 {
 	return point
 }
 
-// Same as the 2D version, except the line is in 3D space
+// BezierCurve3D same as the 2D version, except the line is in 3D space
 func BezierCurve3D(t float32, cPoints []Vec3) Vec3 {
 	if t < 0.0 || t > 1.0 {
 		panic("Input to bezier has t not in range [0,1]. If you think this is a precision error, use mathgl.Clamp[f|d] before calling this function")
@@ -132,13 +136,16 @@ func BezierCurve3D(t float32, cPoints []Vec3) Vec3 {
 	return point
 }
 
-// Generates a bezier curve with controlPoints cPoints. The numPoints argument
-// determines how many "samples" it makes along the line. For instance, a
-// call to this with numPoints 2 will have exactly two points: the start and end points
-// For any points above 2 it will divide it into numPoints-1 chunks (which means it will generate numPoints-2 vertices other than the beginning and end).
-// So for 3 points it will divide it in half, 4 points into thirds, and so on.
+// MakeBezierCurve2D generates a bezier curve with controlPoints cPoints. The
+// numPoints argument determines how many "samples" it makes along the line. For
+// instance, a call to this with numPoints 2 will have exactly two points: the
+// start and end points For any points above 2 it will divide it into
+// numPoints-1 chunks (which means it will generate numPoints-2 vertices other
+// than the beginning and end). So for 3 points it will divide it in half, 4
+// points into thirds, and so on.
 //
-// This is likely to get rather expensive for anything over perhaps a cubic curve.
+// This is likely to get rather expensive for anything over perhaps a cubic
+// curve.
 func MakeBezierCurve2D(numPoints int, cPoints []Vec2) (line []Vec2) {
 	line = make([]Vec2, numPoints)
 	if numPoints == 0 {
@@ -161,7 +168,7 @@ func MakeBezierCurve2D(numPoints int, cPoints []Vec2) (line []Vec2) {
 	return
 }
 
-// Same as the 2D version, except with the line in 3D space
+// MakeBezierCurve3D same as the 2D version, except with the line in 3D space.
 func MakeBezierCurve3D(numPoints int, cPoints []Vec3) (line []Vec3) {
 	line = make([]Vec3, numPoints)
 	if numPoints == 0 {
@@ -184,11 +191,12 @@ func MakeBezierCurve3D(numPoints int, cPoints []Vec3) (line []Vec3) {
 	return
 }
 
-// Creates a 2-dimensional Bezier surface of arbitrary degree in 3D Space
-// Like the curve functions, if u or v are not in the range [0.0,1.0] the function will panic, use Clamp[f|d]
-// to ensure it is correct.
+// BezierSurface creates a 2-dimensional Bezier surface of arbitrary degree in
+// 3D Space Like the curve functions, if u or v are not in the range [0.0,1.0]
+// the function will panic, use Clamp[f|d] to ensure it is correct.
 //
-// The control point matrix must not be jagged, or this will end up panicking from an index out of bounds exception
+// The control point matrix must not be jagged, or this will end up panicking
+// from an index out of bounds exception
 func BezierSurface(u, v float32, cPoints [][]Vec3) Vec3 {
 	if u < 0.0 || u > 1.0 || v < 1.0 || v > 1.0 {
 		panic("u or v not in range [0.0,1.0] in BezierSurface")
@@ -212,8 +220,9 @@ func BezierSurface(u, v float32, cPoints [][]Vec3) Vec3 {
 	return point
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
-// though the spline may be disjoint. The bezier curves are not required to be in any particular order.
+// BezierSplineInterpolate2D does interpolation over a spline of several bezier
+// curves. Each bezier curve must have a finite range, though the spline may be
+// disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic
 func BezierSplineInterpolate2D(t float32, ranges [][2]float32, cPoints [][]Vec2) Vec2 {
@@ -230,8 +239,9 @@ func BezierSplineInterpolate2D(t float32, ranges [][2]float32, cPoints [][]Vec2)
 	panic("t is out of the range of all bezier curves in this spline")
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
-// though the spline may be disjoint. The bezier curves are not required to be in any particular order.
+// BezierSplineInterpolate3D does interpolation over a spline of several bezier
+// curves. Each bezier curve must have a finite range, though the spline may be
+// disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic
 func BezierSplineInterpolate3D(t float32, ranges [][2]float32, cPoints [][]Vec3) Vec3 {
@@ -248,7 +258,7 @@ func BezierSplineInterpolate3D(t float32, ranges [][2]float32, cPoints [][]Vec3)
 	panic("t is out of the range of all bezier curves in this spline")
 }
 
-// Reticulates ALL the Splines
+// ReticulateSplines reticulates ALL the Splines.
 //
 // For the overly serious: the function is just for fun. It does nothing except prints a Maxis reference. Technically you could "reticulate splines"
 // by joining a bunch of splines together, but that ruins the joke.
@@ -260,7 +270,7 @@ func ReticulateSplines(ranges [][][2]float32, cPoints [][][]Vec2, withLlamas boo
 	}
 }
 
-// Transform from pixel coordinates to GL coordinates.
+// ScreenToGLCoords transforms from pixel coordinates to GL coordinates.
 //
 // This assumes that your pixel coordinate system considers its origin to be in the top left corner (GL's is in the bottom left).
 // The coordinates x and y may be out of the range [0,screenWidth-1] and [0,screeneHeight-1].
@@ -276,7 +286,7 @@ func ScreenToGLCoords(x, y int, screenWidth, screenHeight int) (xOut, yOut float
 	return
 }
 
-// Transform from GL's proportional system to pixel coordinates.
+// GLToScreenCoords transforms from GL's proportional system to pixel coordinates.
 //
 // Assumes the pixel coordinate system has its origin in the top left corner. (GL's is in the bottom left)
 //

--- a/mgl32/transform.go
+++ b/mgl32/transform.go
@@ -74,14 +74,14 @@ func Translate3D(Tx, Ty, Tz float32) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, float32(Tx), float32(Ty), float32(Tz), 1}
 }
 
-// Same as Rotate2D, except homogeneous (3x3 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate2D is the same as Rotate2D, except homogeneous (3x3 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate2D(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
-// Same as Rotate3DX, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate3DX is the same as Rotate3DX, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DX(angle float32) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
@@ -89,14 +89,14 @@ func HomogRotate3DX(angle float32) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, cos, sin, 0, 0, -sin, cos, 0, 0, 0, 0, 1}
 }
 
-// Same as Rotate3DY, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate3DY is the same as Rotate3DY, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DY(angle float32) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
 	return Mat4{cos, 0, -sin, 0, 0, 1, 0, 0, sin, 0, cos, 0, 0, 0, 0, 1}
 }
 
-// Same as Rotate3DZ, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate3DZ is the same as Rotate3DZ, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DZ(angle float32) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
@@ -164,14 +164,14 @@ func HomogRotate3D(angle float32, axis Vec3) Mat4 {
 	return Mat4{x*x*k + c, x*y*k + z*s, x*z*k - y*s, 0, x*y*k - z*s, y*y*k + c, y*z*k + x*s, 0, x*z*k + y*s, y*z*k - x*s, z*z*k + c, 0, 0, 0, 0, 1}
 }
 
-// Extracts the 3d scaling from a homogeneous matrix
+// Extract3DScale extracts the 3d scaling from a homogeneous matrix
 func Extract3DScale(m Mat4) (x, y, z float32) {
 	return float32(math.Sqrt(float64(m[0]*m[0] + m[1]*m[1] + m[2]*m[2]))),
 		float32(math.Sqrt(float64(m[4]*m[4] + m[5]*m[5] + m[6]*m[6]))),
 		float32(math.Sqrt(float64(m[8]*m[8] + m[9]*m[9] + m[10]*m[10])))
 }
 
-// Extracts the maximum scaling from a homogeneous matrix
+// ExtractMaxScale extracts the maximum scaling from a homogeneous matrix
 func ExtractMaxScale(m Mat4) float32 {
 	scaleX := float64(m[0]*m[0] + m[1]*m[1] + m[2]*m[2])
 	scaleY := float64(m[4]*m[4] + m[5]*m[5] + m[6]*m[6])
@@ -180,13 +180,13 @@ func ExtractMaxScale(m Mat4) float32 {
 	return float32(math.Sqrt(math.Max(scaleX, math.Max(scaleY, scaleZ))))
 }
 
-// Calculates the Normal of the Matrix (aka the inverse transpose)
+// Mat4Normal calculates the Normal of the Matrix (aka the inverse transpose)
 func Mat4Normal(m Mat4) Mat3 {
 	n := m.Inv().Transpose()
 	return Mat3{n[0], n[1], n[2], n[4], n[5], n[6], n[8], n[9], n[10]}
 }
 
-// Multiplies a 3D vector by a transformation given by
+// TransformCoordinate multiplies a 3D vector by a transformation given by
 // the homogeneous 4D matrix m, applying any translation.
 // If this transformation is non-affine, it will project this
 // vector onto the plane w=1 before returning the result.
@@ -205,7 +205,7 @@ func TransformCoordinate(v Vec3, m Mat4) Vec3 {
 	return t.Vec3()
 }
 
-// Multiplies a 3D vector by a transformation given by
+// TransformNormal multiplies a 3D vector by a transformation given by
 // the homogeneous 4D matrix m, NOT applying any translations.
 //
 // This is similar to saying you're applying a transformation

--- a/mgl32/util.go
+++ b/mgl32/util.go
@@ -21,7 +21,7 @@ import (
 // are being executed when you change this.
 var Epsilon float32 = 1e-10
 
-// A direct copy of the math package's Abs. This is here for the mgl32
+// Abs is a direct copy of the math package's Abs. This is here for the mgl32
 // package, to prevent rampant type conversions during equality tests.
 func Abs(a float32) float32 {
 	if a < 0 {
@@ -50,6 +50,7 @@ func FloatEqualFunc(epsilon float32) func(float32, float32) bool {
 	}
 }
 
+// Various useful constants.
 var (
 	MinNormal = float32(1.1754943508222875e-38) // 1 / 2**(127 - 1)
 	MinValue  = float32(math.SmallestNonzeroFloat32)
@@ -104,26 +105,27 @@ func ClampFunc(low, high float32) func(float32) float32 {
 	}
 }
 
-/* The IsClamped functions use strict equality (meaning: not the FloatEqual function)
-there shouldn't be any major issues with this since clamp is often used to fix minor errors*/
-
-// Checks if a is clamped between low and high as if
+// IsClamped checks if a is clamped between low and high as if
 // Clamp(a, low, high) had been called.
 //
 // In most cases it's probably better to just call Clamp
 // without checking this since it's relatively cheap.
+//
+// The IsClamped functions use strict equality (meaning: not the FloatEqual
+// function) there shouldn't be any major issues with this since clamp is often
+// used to fix minor errors
 func IsClamped(a, low, high float32) bool {
 	return a >= low && a <= high
 }
 
-// If a > b, then a will be set to the value of b.
+// SetMin sets a to b if a > b.
 func SetMin(a, b *float32) {
 	if *b < *a {
 		*a = *b
 	}
 }
 
-// If a < b, then a will be set to the value of b.
+// SetMax sets a to b if a < b.
 func SetMax(a, b *float32) {
 	if *a < *b {
 		*a = *b

--- a/mgl32/vecn.go
+++ b/mgl32/vecn.go
@@ -8,7 +8,7 @@ import (
 	"math"
 )
 
-// A vector of N elements backed by a slice
+// VecN represents a vector of N elements backed by a slice.
 //
 // As with MatMxN, this is not for hardcore linear algebra with large dimensions. Use github.com/gonum/matrix
 // or something like BLAS/LAPACK for that. This is for corner cases in 3D math where you require
@@ -21,7 +21,7 @@ type VecN struct {
 	vec []float32
 }
 
-// Creates a new vector with a backing slice filled with the contents
+// NewVecNFromData creates a new vector with a backing slice filled with the contents
 // of initial. It is NOT backed by initial, but rather a slice with cap
 // 2^p where p is Ceil(log_2(len(initial))), with the data from initial copied into
 // it.
@@ -39,7 +39,7 @@ func NewVecNFromData(initial []float32) *VecN {
 	return &VecN{vec: internal}
 }
 
-// Creates a new vector with a backing slice of
+// NewVecN creates a new vector with a backing slice of
 // 2^p where p = Ceil(log_2(n))
 func NewVecN(n int) *VecN {
 	if shouldPool {
@@ -49,7 +49,7 @@ func NewVecN(n int) *VecN {
 	}
 }
 
-// Returns the raw slice backing the VecN
+// Raw returns the raw slice backing the VecN
 //
 // This may be sent back to the memory pool at any time
 // and you aren't advised to rely on this value
@@ -57,13 +57,13 @@ func (vn VecN) Raw() []float32 {
 	return vn.vec
 }
 
-// Gets the element at index i from the vector.
-// This does not bounds check, and will panic if i is
-// out of range.
+// Get the element at index i from the vector. This does not bounds check, and
+// will panic if i is out of range.
 func (vn VecN) Get(i int) float32 {
 	return vn.vec[i]
 }
 
+// Set the element at index i to val.
 func (vn *VecN) Set(i int, val float32) {
 	vn.vec[i] = val
 }
@@ -80,11 +80,12 @@ func (vn *VecN) destroy() {
 	vn.vec = nil
 }
 
-// Resizes the underlying slice to the desired amount, reallocating or retrieving from the pool
-// if necessary. The values after a Resize cannot be expected to be related to the values before a Resize.
+// Resize the underlying slice to the desired amount, reallocating or retrieving
+// from the pool if necessary. The values after a Resize cannot be expected to
+// be related to the values before a Resize.
 //
-// If the caller is a nil pointer, this returns a value as if NewVecN(n) had been called,
-// otherwise it simply returns the caller.
+// If the caller is a nil pointer, this returns a value as if NewVecN(n) had
+// been called, otherwise it simply returns the caller.
 func (vn *VecN) Resize(n int) *VecN {
 	if vn == nil {
 		return NewVecN(n)
@@ -107,25 +108,25 @@ func (vn *VecN) Resize(n int) *VecN {
 	return vn
 }
 
-// Sets the vector's backing slice to the given
+// SetBackingSlice sets the vector's backing slice to the given
 // new one.
 func (vn *VecN) SetBackingSlice(newSlice []float32) {
 	vn.vec = newSlice
 }
 
-// Return the len of the vector's underlying slice.
+// Size returns the len of the vector's underlying slice.
 // This is not titled Len because it conflicts the package's
 // convention of calling the Norm the Len.
 func (vn *VecN) Size() int {
 	return len(vn.vec)
 }
 
-// Returns the cap of the vector's underlying slice.
+// Cap Returns the cap of the vector's underlying slice.
 func (vn *VecN) Cap() int {
 	return cap(vn.vec)
 }
 
-// Sets the vector's size to n and zeroes out the vector.
+// Zero sets the vector's size to n and zeroes out the vector.
 // If n is bigger than the vector's size, it will realloc.
 func (vn *VecN) Zero(n int) {
 	vn.Resize(n)
@@ -134,7 +135,7 @@ func (vn *VecN) Zero(n int) {
 	}
 }
 
-// Adds vn and addend, storing the result in dst.
+// Add adds vn and addend, storing the result in dst.
 // If dst does not have sufficient size it will be resized
 // Dst may be one of the other arguments. If dst is nil, it will be allocated.
 // The value returned is dst, for easier method chaining
@@ -155,7 +156,7 @@ func (vn *VecN) Add(dst *VecN, subtrahend *VecN) *VecN {
 	return dst
 }
 
-// Subtracts addend from vn, storing the result in dst.
+// Sub subtracts addend from vn, storing the result in dst.
 // If dst does not have sufficient size it will be resized
 // Dst may be one of the other arguments. If dst is nil, it will be allocated.
 // The value returned is dst, for easier method chaining
@@ -176,7 +177,7 @@ func (vn *VecN) Sub(dst *VecN, addend *VecN) *VecN {
 	return dst
 }
 
-// Takes the binary cross product of vn and other, and stores it in dst.
+// Cross takes the binary cross product of vn and other, and stores it in dst.
 // If either vn or other are not of size 3 this function will panic
 //
 // If dst is not of sufficient size, or is nil, a new slice is allocated.
@@ -203,7 +204,7 @@ func intMin(a, b int) int {
 	return b
 }
 
-// Computes the dot product of two VecNs, if
+// Dot computes the dot product of two VecNs, if
 // the two vectors are not of the same length -- this
 // will return NaN.
 func (vn *VecN) Dot(other *VecN) float32 {
@@ -219,7 +220,7 @@ func (vn *VecN) Dot(other *VecN) float32 {
 	return result
 }
 
-// Computes the vector length (also called the Norm) of the
+// Len computes the vector length (also called the Norm) of the
 // vector. Equivalent to math.Sqrt(vn.Dot(vn)) with the appropriate
 // type conversions.
 //
@@ -235,7 +236,7 @@ func (vn *VecN) Len() float32 {
 	return float32(math.Sqrt(float64(vn.Dot(vn))))
 }
 
-// Normalizes the vector and stores the result in dst, which
+// Normalize the vector and stores the result in dst, which
 // will be returned. Dst will be appropraitely resized to the
 // size of vn.
 //
@@ -250,9 +251,8 @@ func (vn *VecN) Normalize(dst *VecN) *VecN {
 	return vn.Mul(dst, 1/vn.Len())
 }
 
-// Multiplied the vector by some scalar value and stores the result in dst, which
-// will be returned. Dst will be appropraitely resized to the
-// size of vn.
+// Mul multiplies the vector by some scalar value and stores the result in dst,
+// which will be returned. Dst will be appropriately resized to the size of vn.
 //
 // The destination can be vn itself and nothing will go wrong.
 func (vn *VecN) Mul(dst *VecN, c float32) *VecN {
@@ -268,7 +268,7 @@ func (vn *VecN) Mul(dst *VecN, c float32) *VecN {
 	return dst
 }
 
-// Performs the vector outer product between vn and v2.
+// OuterProd performs the vector outer product between vn and v2.
 // The outer product is like a "reverse" dot product. Where the dot product
 // aligns both vectors with the "sized" part facing "inward" (Vec3*Vec3=Mat1x3*Mat3x1=Mat1x1=Scalar).
 // The outer product multiplied them with it facing "outward"
@@ -292,6 +292,8 @@ func (vn *VecN) OuterProd(dst *MatMxN, v2 *VecN) *MatMxN {
 	return dst
 }
 
+// ApproxEqual returns whether the two vectors are approximately equal (See
+// FloatEqual).
 func (vn *VecN) ApproxEqual(vn2 *VecN) bool {
 	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
 		return false
@@ -306,6 +308,8 @@ func (vn *VecN) ApproxEqual(vn2 *VecN) bool {
 	return true
 }
 
+// ApproxEqualThreshold returns whether the two vectors are approximately equal
+// to within the given threshold given by "epsilon" (See ApproxEqualThreshold).
 func (vn *VecN) ApproxEqualThreshold(vn2 *VecN, epsilon float32) bool {
 	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
 		return false
@@ -320,6 +324,8 @@ func (vn *VecN) ApproxEqualThreshold(vn2 *VecN, epsilon float32) bool {
 	return true
 }
 
+// ApproxEqualFunc returns whether the two vectors are approximately equal,
+// given a function which compares two scalar elements.
 func (vn *VecN) ApproxEqualFunc(vn2 *VecN, comp func(float32, float32) bool) bool {
 	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
 		return false
@@ -334,16 +340,19 @@ func (vn *VecN) ApproxEqualFunc(vn2 *VecN, comp func(float32, float32) bool) boo
 	return true
 }
 
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
 func (vn *VecN) Vec2() Vec2 {
 	raw := vn.Raw()
 	return Vec2{raw[0], raw[1]}
 }
 
+// Vec3 constructs a 3-dimensional vector by discarding coordinates.
 func (vn *VecN) Vec3() Vec3 {
 	raw := vn.Raw()
 	return Vec3{raw[0], raw[1], raw[2]}
 }
 
+// Vec4 constructs a 4-dimensional vector by discarding coordinates.
 func (vn *VecN) Vec4() Vec4 {
 	raw := vn.Raw()
 	return Vec4{raw[0], raw[1], raw[2], raw[3]}

--- a/mgl32/vector.go
+++ b/mgl32/vector.go
@@ -16,26 +16,32 @@ type Vec2 f32.Vec2
 type Vec3 f32.Vec3
 type Vec4 f32.Vec4
 
+// Vec3 constructs a 3-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec3(z float32) Vec3 {
 	return Vec3{v[0], v[1], z}
 }
 
+// Vec4 constructs a 4-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec4(z, w float32) Vec4 {
 	return Vec4{v[0], v[1], z, w}
 }
 
-func (v Vec3) Vec2() Vec2 {
-	return Vec2{v[0], v[1]}
-}
-
+// Vec4 constructs a 4-dimensional vector by appending the given coordinates.
 func (v Vec3) Vec4(w float32) Vec4 {
 	return Vec4{v[0], v[1], v[2], w}
 }
 
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
+func (v Vec3) Vec2() Vec2 {
+	return Vec2{v[0], v[1]}
+}
+
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
 func (v Vec4) Vec2() Vec2 {
 	return Vec2{v[0], v[1]}
 }
 
+// Vec3 constructs a 3-dimensional vector by discarding coordinates.
 func (v Vec4) Vec3() Vec3 {
 	return Vec3{v[0], v[1], v[2]}
 }
@@ -55,25 +61,28 @@ func (v Vec4) Elem() (x, y, z, w float32) {
 	return v[0], v[1], v[2], v[3]
 }
 
-// The vector cross product is an operation only defined on 3D vectors. It is equivalent to
-// Vec3{v1[1]*v2[2]-v1[2]*v2[1], v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}.
-// Another interpretation is that it's the vector whose magnitude is |v1||v2|sin(theta)
-// where theta is the angle between v1 and v2.
+// Cross is the vector cross product. This operation is only defined on 3D
+// vectors. It is equivalent to Vec3{v1[1]*v2[2]-v1[2]*v2[1],
+// v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}. Another interpretation
+// is that it's the vector whose magnitude is |v1||v2|sin(theta) where theta is
+// the angle between v1 and v2.
 //
-// The cross product is most often used for finding surface normals. The cross product of vectors
-// will generate a vector that is perpendicular to the plane they form.
+// The cross product is most often used for finding surface normals. The cross
+// product of vectors will generate a vector that is perpendicular to the plane
+// they form.
 //
 // Technically, a generalized cross product exists as an "(N-1)ary" operation
-// (that is, the 4D cross product requires 3 4D vectors). But the binary
-// 3D (and 7D) cross product is the most important. It can be considered
-// the area of a parallelogram with sides v1 and v2.
+// (that is, the 4D cross product requires 3 4D vectors). But the binary 3D (and
+// 7D) cross product is the most important. It can be considered the area of a
+// parallelogram with sides v1 and v2.
 //
-// Like the dot product, the cross product is roughly a measure of directionality.
-// Two normalized perpendicular vectors will return a vector with a magnitude of
-// 1.0 or -1.0 and two parallel vectors will return a vector with magnitude 0.0.
-// The cross product is "anticommutative" meaning v1.Cross(v2) = -v2.Cross(v1),
-// this property can be useful to know when finding normals,
-// as taking the wrong cross product can lead to the opposite normal of the one you want.
+// Like the dot product, the cross product is roughly a measure of
+// directionality. Two normalized perpendicular vectors will return a vector
+// with a magnitude of 1.0 or -1.0 and two parallel vectors will return a vector
+// with magnitude 0.0. The cross product is "anticommutative" meaning
+// v1.Cross(v2) = -v2.Cross(v1), this property can be useful to know when
+// finding normals, as taking the wrong cross product can lead to the opposite
+// normal of the one you want.
 func (v1 Vec3) Cross(v2 Vec3) Vec3 {
 	return Vec3{v1[1]*v2[2] - v1[2]*v2[1], v1[2]*v2[0] - v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}
 }
@@ -137,8 +146,8 @@ func (v1 Vec2) Normalize() Vec2 {
 	return Vec2{v1[0] * l, v1[1] * l}
 }
 
-// ApproxEqual takes in a vector and does an element-wise
-// approximate float comparison as if FloatEqual had been used
+// ApproxEqual takes in a vector and does an element-wise approximate float
+// comparison as if FloatEqual had been used
 func (v1 Vec2) ApproxEqual(v2 Vec2) bool {
 	for i := range v1 {
 		if !FloatEqual(v1[i], v2[i]) {
@@ -148,8 +157,8 @@ func (v1 Vec2) ApproxEqual(v2 Vec2) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
-// element-wise comparison of the vector to another.
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses
+// it to do an element-wise comparison of the vector to another.
 func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float32) bool {
 	for i := range v1 {
 		if !FloatEqualThreshold(v1[i], v2[i], threshold) {
@@ -159,7 +168,7 @@ func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float32) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec2) ApproxFuncEqual(v2 Vec2, eq func(float32, float32) bool) bool {
 	for i := range v1 {
@@ -170,7 +179,7 @@ func (v1 Vec2) ApproxFuncEqual(v2 Vec2, eq func(float32, float32) bool) bool {
 	return true
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// X is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -178,7 +187,7 @@ func (v Vec2) X() float32 {
 	return v[0]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Y is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -186,7 +195,7 @@ func (v Vec2) Y() float32 {
 	return v[1]
 }
 
-// Does the vector outer product
+// OuterProd2 does the vector outer product
 // of two vectors. The outer product produces an
 // 2x2 matrix. E.G. a Vec2 * Vec2 = Mat2.
 //
@@ -201,7 +210,7 @@ func (v1 Vec2) OuterProd2(v2 Vec2) Mat2 {
 	return Mat2{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 does the vector outer product
 // of two vectors. The outer product produces an
 // 2x3 matrix. E.G. a Vec2 * Vec3 = Mat2x3.
 //
@@ -216,7 +225,7 @@ func (v1 Vec2) OuterProd3(v2 Vec3) Mat2x3 {
 	return Mat2x3{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[0] * v2[2], v1[1] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 does the vector outer product
 // of two vectors. The outer product produces an
 // 2x4 matrix. E.G. a Vec2 * Vec4 = Mat2x4.
 //
@@ -290,8 +299,8 @@ func (v1 Vec3) Normalize() Vec3 {
 	return Vec3{v1[0] * l, v1[1] * l, v1[2] * l}
 }
 
-// ApproxEqual takes in a vector and does an element-wise
-// approximate float comparison as if FloatEqual had been used
+// ApproxEqual takes in a vector and does an element-wise approximate float
+// comparison as if FloatEqual had been used
 func (v1 Vec3) ApproxEqual(v2 Vec3) bool {
 	for i := range v1 {
 		if !FloatEqual(v1[i], v2[i]) {
@@ -301,8 +310,8 @@ func (v1 Vec3) ApproxEqual(v2 Vec3) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
-// element-wise comparison of the vector to another.
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses
+// it to do an element-wise comparison of the vector to another.
 func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float32) bool {
 	for i := range v1 {
 		if !FloatEqualThreshold(v1[i], v2[i], threshold) {
@@ -312,7 +321,7 @@ func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float32) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec3) ApproxFuncEqual(v2 Vec3, eq func(float32, float32) bool) bool {
 	for i := range v1 {
@@ -323,7 +332,7 @@ func (v1 Vec3) ApproxFuncEqual(v2 Vec3, eq func(float32, float32) bool) bool {
 	return true
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// X is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -331,7 +340,7 @@ func (v Vec3) X() float32 {
 	return v[0]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Y is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -339,7 +348,7 @@ func (v Vec3) Y() float32 {
 	return v[1]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Z is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -347,7 +356,7 @@ func (v Vec3) Z() float32 {
 	return v[2]
 }
 
-// Does the vector outer product
+// OuterProd2 does the vector outer product
 // of two vectors. The outer product produces an
 // 3x2 matrix. E.G. a Vec3 * Vec2 = Mat3x2.
 //
@@ -362,7 +371,7 @@ func (v1 Vec3) OuterProd2(v2 Vec2) Mat3x2 {
 	return Mat3x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 does the vector outer product
 // of two vectors. The outer product produces an
 // 3x3 matrix. E.G. a Vec3 * Vec3 = Mat3.
 //
@@ -377,7 +386,7 @@ func (v1 Vec3) OuterProd3(v2 Vec3) Mat3 {
 	return Mat3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 does the vector outer product
 // of two vectors. The outer product produces an
 // 3x4 matrix. E.G. a Vec3 * Vec4 = Mat3x4.
 //
@@ -451,8 +460,8 @@ func (v1 Vec4) Normalize() Vec4 {
 	return Vec4{v1[0] * l, v1[1] * l, v1[2] * l, v1[3] * l}
 }
 
-// ApproxEqual takes in a vector and does an element-wise
-// approximate float comparison as if FloatEqual had been used
+// ApproxEqual takes in a vector and does an element-wise approximate float
+// comparison as if FloatEqual had been used
 func (v1 Vec4) ApproxEqual(v2 Vec4) bool {
 	for i := range v1 {
 		if !FloatEqual(v1[i], v2[i]) {
@@ -462,8 +471,8 @@ func (v1 Vec4) ApproxEqual(v2 Vec4) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
-// element-wise comparison of the vector to another.
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses
+// it to do an element-wise comparison of the vector to another.
 func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float32) bool {
 	for i := range v1 {
 		if !FloatEqualThreshold(v1[i], v2[i], threshold) {
@@ -473,7 +482,7 @@ func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float32) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec4) ApproxFuncEqual(v2 Vec4, eq func(float32, float32) bool) bool {
 	for i := range v1 {
@@ -484,7 +493,7 @@ func (v1 Vec4) ApproxFuncEqual(v2 Vec4, eq func(float32, float32) bool) bool {
 	return true
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// X is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -492,7 +501,7 @@ func (v Vec4) X() float32 {
 	return v[0]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Y is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -500,7 +509,7 @@ func (v Vec4) Y() float32 {
 	return v[1]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Z is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -508,7 +517,7 @@ func (v Vec4) Z() float32 {
 	return v[2]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// W is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -516,7 +525,7 @@ func (v Vec4) W() float32 {
 	return v[3]
 }
 
-// Does the vector outer product
+// OuterProd2 does the vector outer product
 // of two vectors. The outer product produces an
 // 4x2 matrix. E.G. a Vec4 * Vec2 = Mat4x2.
 //
@@ -531,7 +540,7 @@ func (v1 Vec4) OuterProd2(v2 Vec2) Mat4x2 {
 	return Mat4x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 does the vector outer product
 // of two vectors. The outer product produces an
 // 4x3 matrix. E.G. a Vec4 * Vec3 = Mat4x3.
 //
@@ -546,7 +555,7 @@ func (v1 Vec4) OuterProd3(v2 Vec3) Mat4x3 {
 	return Mat4x3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2], v1[3] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 does the vector outer product
 // of two vectors. The outer product produces an
 // 4x4 matrix. E.G. a Vec4 * Vec4 = Mat4.
 //

--- a/mgl32/vector.tmpl
+++ b/mgl32/vector.tmpl
@@ -16,26 +16,32 @@ type Vec2 f32.Vec2
 type Vec3 f32.Vec3
 type Vec4 f32.Vec4
 
+// Vec3 constructs a 3-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec3(z float32) Vec3 {
 	return Vec3{v[0], v[1], z}
 }
 
+// Vec4 constructs a 4-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec4(z, w float32) Vec4 {
 	return Vec4{v[0], v[1], z, w}
 }
 
-func (v Vec3) Vec2() Vec2 {
-	return Vec2{v[0], v[1]}
-}
-
+// Vec4 constructs a 4-dimensional vector by appending the given coordinates.
 func (v Vec3) Vec4(w float32) Vec4 {
 	return Vec4{v[0], v[1], v[2], w}
 }
 
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
+func (v Vec3) Vec2() Vec2 {
+	return Vec2{v[0], v[1]}
+}
+
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
 func (v Vec4) Vec2() Vec2 {
 	return Vec2{v[0], v[1]}
 }
 
+// Vec3 constructs a 3-dimensional vector by discarding coordinates.
 func (v Vec4) Vec3() Vec3 {
 	return Vec3{v[0], v[1], v[2]}
 }
@@ -55,25 +61,28 @@ func (v Vec4) Elem() (x, y, z, w float32) {
 	return v[0], v[1], v[2], v[3]
 }
 
-// The vector cross product is an operation only defined on 3D vectors. It is equivalent to
-// Vec3{v1[1]*v2[2]-v1[2]*v2[1], v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}.
-// Another interpretation is that it's the vector whose magnitude is |v1||v2|sin(theta)
-// where theta is the angle between v1 and v2.
+// Cross is the vector cross product. This operation is only defined on 3D
+// vectors. It is equivalent to Vec3{v1[1]*v2[2]-v1[2]*v2[1],
+// v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}. Another interpretation
+// is that it's the vector whose magnitude is |v1||v2|sin(theta) where theta is
+// the angle between v1 and v2.
 //
-// The cross product is most often used for finding surface normals. The cross product of vectors
-// will generate a vector that is perpendicular to the plane they form.
+// The cross product is most often used for finding surface normals. The cross
+// product of vectors will generate a vector that is perpendicular to the plane
+// they form.
 //
 // Technically, a generalized cross product exists as an "(N-1)ary" operation
-// (that is, the 4D cross product requires 3 4D vectors). But the binary
-// 3D (and 7D) cross product is the most important. It can be considered
-// the area of a parallelogram with sides v1 and v2.
+// (that is, the 4D cross product requires 3 4D vectors). But the binary 3D (and
+// 7D) cross product is the most important. It can be considered the area of a
+// parallelogram with sides v1 and v2.
 //
-// Like the dot product, the cross product is roughly a measure of directionality.
-// Two normalized perpendicular vectors will return a vector with a magnitude of
-// 1.0 or -1.0 and two parallel vectors will return a vector with magnitude 0.0.
-// The cross product is "anticommutative" meaning v1.Cross(v2) = -v2.Cross(v1),
-// this property can be useful to know when finding normals,
-// as taking the wrong cross product can lead to the opposite normal of the one you want.
+// Like the dot product, the cross product is roughly a measure of
+// directionality. Two normalized perpendicular vectors will return a vector
+// with a magnitude of 1.0 or -1.0 and two parallel vectors will return a vector
+// with magnitude 0.0. The cross product is "anticommutative" meaning
+// v1.Cross(v2) = -v2.Cross(v1), this property can be useful to know when
+// finding normals, as taking the wrong cross product can lead to the opposite
+// normal of the one you want.
 func (v1 Vec3) Cross(v2 Vec3) Vec3 {
 	return Vec3{v1[1]*v2[2] - v1[2]*v2[1], v1[2]*v2[0] - v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}
 }
@@ -144,8 +153,8 @@ func (v1 <<$type>>) Normalize() <<$type>> {
 	return <<$type>>{<<range $i := iter 0 $m>>v1[<<$i>>] * l,<<end>>}
 }
 
-// ApproxEqual takes in a vector and does an element-wise
-// approximate float comparison as if FloatEqual had been used
+// ApproxEqual takes in a vector and does an element-wise approximate float
+// comparison as if FloatEqual had been used
 func (v1 <<$type>>) ApproxEqual(v2 <<$type>>) bool {
 	for i := range v1 {
 		if !FloatEqual(v1[i], v2[i]) {
@@ -155,8 +164,8 @@ func (v1 <<$type>>) ApproxEqual(v2 <<$type>>) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
-// element-wise comparison of the vector to another.
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses
+// it to do an element-wise comparison of the vector to another.
 func (v1 <<$type>>) ApproxEqualThreshold(v2 <<$type>>, threshold float32) bool {
 	for i := range v1 {
 		if !FloatEqualThreshold(v1[i], v2[i], threshold) {
@@ -166,7 +175,7 @@ func (v1 <<$type>>) ApproxEqualThreshold(v2 <<$type>>, threshold float32) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 <<$type>>) ApproxFuncEqual(v2 <<$type>>, eq func(float32, float32) bool) bool {
 	for i := range v1 {
@@ -178,7 +187,7 @@ func (v1 <<$type>>) ApproxFuncEqual(v2 <<$type>>, eq func(float32, float32) bool
 }
 
 <<range $i := iter 0 $m>>
-// This is an element access func, it is equivalent to v[n] where
+// <<elementname $i>> is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -188,7 +197,7 @@ func (v <<$type>>) <<elementname $i>>() float32 {
 <<end>>
 
 <<range $n := enum 2 3 4>>
-// Does the vector outer product
+// OuterProd<<$n>> does the vector outer product
 // of two vectors. The outer product produces an
 // <<$m>>x<<$n>> matrix. E.G. a Vec<<$m>> * Vec<<$n>> = <<typename $m $n>>.
 //

--- a/mgl64/conv.go
+++ b/mgl64/conv.go
@@ -10,7 +10,7 @@ import (
 	"math"
 )
 
-// Converts 3-dimensional cartesian coordinates (x,y,z) to spherical
+// CartesianToSpherical converts 3-dimensional cartesian coordinates (x,y,z) to spherical
 // coordinates with radius r, inclination theta, and azimuth phi.
 //
 // All angles are in radians.
@@ -22,8 +22,8 @@ func CartesianToSpherical(coord Vec3) (r, theta, phi float64) {
 	return
 }
 
-// Converts 3-dimensional cartesian coordinates (x,y,z) to cylindrical
-// coordinates with radial distance r, azimuth phi, and height z.
+// CartesianToCylindical converts 3-dimensional cartesian coordinates (x,y,z) to
+// cylindrical coordinates with radial distance r, azimuth phi, and height z.
 //
 // All angles are in radians.
 func CartesianToCylindical(coord Vec3) (rho, phi, z float64) {
@@ -36,7 +36,7 @@ func CartesianToCylindical(coord Vec3) (rho, phi, z float64) {
 	return
 }
 
-// Converts spherical coordinates with radius r, inclination theta,
+// SphericalToCartesian converts spherical coordinates with radius r, inclination theta,
 // and azimuth phi to cartesian coordinates (x,y,z).
 //
 // Angles are in radians.
@@ -47,9 +47,9 @@ func SphericalToCartesian(r, theta, phi float64) Vec3 {
 	return Vec3{r * float64(st*cp), r * float64(st*sp), r * float64(ct)}
 }
 
-// Converts spherical coordinates with radius r, inclination theta,
-// and azimuth phi to cylindrical coordinates with radial distance r,
-// azimuth phi, and height z.
+// SphericalToCylindrical converts spherical coordinates with radius r,
+// inclination theta, and azimuth phi to cylindrical coordinates with radial
+// distance r, azimuth phi, and height z.
 //
 // Angles are in radians
 func SphericalToCylindrical(r, theta, phi float64) (rho, phi2, z float64) {
@@ -62,8 +62,8 @@ func SphericalToCylindrical(r, theta, phi float64) (rho, phi2, z float64) {
 	return
 }
 
-// Converts cylindrical coordinates with radial distance r,
-// azimuth phi, and height z to spherical coordinates with radius r,
+// CylindircalToSpherical converts cylindrical coordinates with radial distance
+// r, azimuth phi, and height z to spherical coordinates with radius r,
 // inclination theta, and azimuth phi.
 //
 // Angles are in radians
@@ -75,8 +75,8 @@ func CylindircalToSpherical(rho, phi, z float64) (r, theta, phi2 float64) {
 	return
 }
 
-// Converts cylindrical coordinates with radial distance r,
-// azimuth phi, and height z to cartesian coordinates (x,y,z)
+// CylindricalToCartesian converts cylindrical coordinates with radial distance
+// r, azimuth phi, and height z to cartesian coordinates (x,y,z)
 //
 // Angles are in radians.
 func CylindricalToCartesian(rho, phi, z float64) Vec3 {
@@ -85,12 +85,12 @@ func CylindricalToCartesian(rho, phi, z float64) Vec3 {
 	return Vec3{rho * float64(c), rho * float64(s), z}
 }
 
-// Converts degrees to radians
+// DegToRad converts degrees to radians
 func DegToRad(angle float64) float64 {
 	return angle * float64(math.Pi) / 180
 }
 
-// Converts radians to degrees
+// RadToDeg converts radians to degrees
 func RadToDeg(angle float64) float64 {
 	return angle * 180 / float64(math.Pi)
 }

--- a/mgl64/matmn.go
+++ b/mgl64/matmn.go
@@ -10,7 +10,7 @@ import (
 	"math"
 )
 
-// An arbitrary mxn matrix backed by a slice of floats.
+// MatMxN is an arbitrary mxn matrix backed by a slice of floats.
 //
 // This is emphatically not recommended for hardcore n-dimensional
 // linear algebra. For that purpose I recommend github.com/gonum/matrix or
@@ -29,7 +29,7 @@ type MatMxN struct {
 	dat  []float64
 }
 
-// Creates a matrix backed by a new slice of size m*n
+// NewMatrix creates a matrix backed by a new slice of size m*n
 func NewMatrix(m, n int) (mat *MatMxN) {
 	if shouldPool {
 		return &MatMxN{m: m, n: n, dat: grabFromPool(m * n)}
@@ -38,16 +38,15 @@ func NewMatrix(m, n int) (mat *MatMxN) {
 	}
 }
 
-// Returns a matrix with data specified by the data in src
+// NewMatrixFromData returns a matrix with data specified by the data in src
 //
 // For instance, to create a 3x3 MatMN from a Mat3
 //
 //    m1 := mgl32.Rotate3DX(3.14159)
 //    mat := mgl32.NewBackedMatrix(m1[:],3,3)
 //
-// will create an MN matrix matching the data in the original
-// rotation matrix. This matrix is NOT backed by the initial slice;
-// it's a copy of the data
+// will create an MN matrix matching the data in the original rotation matrix.
+// This matrix is NOT backed by the initial slice; it's a copy of the data
 //
 // If m*n > cap(src), this function will panic.
 func NewMatrixFromData(src []float64, m, n int) *MatMxN {
@@ -62,7 +61,7 @@ func NewMatrixFromData(src []float64, m, n int) *MatMxN {
 	return &MatMxN{m: m, n: n, dat: internal}
 }
 
-// Copies src into dst. This Reshapes dst
+// CopyMatMN copies src into dst. This Reshapes dst
 // to the same size as src.
 //
 // If dst or src is nil, this is a no-op
@@ -74,7 +73,7 @@ func CopyMatMN(dst, src *MatMxN) {
 	copy(dst.dat, src.dat)
 }
 
-// Stores the NxN identity matrix in dst, reallocating as necessary.
+// IdentN stores the NxN identity matrix in dst, reallocating as necessary.
 func IdentN(dst *MatMxN, n int) *MatMxN {
 	dst = dst.Reshape(n, n)
 
@@ -91,11 +90,12 @@ func IdentN(dst *MatMxN, n int) *MatMxN {
 	return dst
 }
 
-// Creates an NxN diagonal matrix seeded by the diagonal vector
-// diag. Meaning: for all entries, where i==j, dst.At(i,j) = diag[i]. Otherwise
+// DiagN creates an NxN diagonal matrix seeded by the diagonal vector diag.
+// Meaning: for all entries, where i==j, dst.At(i,j) = diag[i]. Otherwise
 // dst.At(i,j) = 0
 //
-// This reshapes dst to the correct size, returning/grabbing from the memory pool as necessary.
+// This reshapes dst to the correct size, returning/grabbing from the memory
+// pool as necessary.
 func DiagN(dst *MatMxN, diag *VecN) *MatMxN {
 	dst = dst.Reshape(len(diag.vec), len(diag.vec))
 	n := len(diag.vec)
@@ -113,7 +113,7 @@ func DiagN(dst *MatMxN, diag *VecN) *MatMxN {
 	return dst
 }
 
-// Reshapes the matrix to m by n and zeroes out all
+// Zero reshapes the matrix to m by n and zeroes out all
 // elements.
 func (mat *MatMxN) Zero(m, n int) {
 	if mat == nil {
@@ -126,7 +126,7 @@ func (mat *MatMxN) Zero(m, n int) {
 	}
 }
 
-// Returns the underlying matrix slice to the memory pool
+// destroy returns the underlying matrix slice to the memory pool
 func (mat *MatMxN) destroy() {
 	if mat == nil {
 		return
@@ -139,7 +139,7 @@ func (mat *MatMxN) destroy() {
 	mat.dat = nil
 }
 
-// Reshapes the matrix to the desired dimensions.
+// Reshape reshapes the matrix to the desired dimensions.
 // If the overall size of the new matrix (m*n) is bigger
 // than the current size, the underlying slice will
 // be grown, sending the current slice to the memory pool
@@ -171,12 +171,13 @@ func (mat *MatMxN) Reshape(m, n int) *MatMxN {
 	return mat
 }
 
-// Infers an MxN matrix from a constant matrix from this package. For instance,
-// a Mat2x3 inferred with this function will work just like NewMatrixFromData(m[:],2,3)
-// where m is the Mat2x3. This uses a type switch.
+// InferMatrix infers an MxN matrix from a constant matrix from this package.
+// For instance, a Mat2x3 inferred with this function will work just like
+// NewMatrixFromData(m[:],2,3) where m is the Mat2x3. This uses a type switch.
 //
-// I personally recommend using NewMatrixFromData, because it avoids a potentially costly type switch.
-// However, this is also more robust and less error prone if you change the size of your matrix somewhere.
+// I personally recommend using NewMatrixFromData, because it avoids a
+// potentially costly type switch. However, this is also more robust and less
+// error prone if you change the size of your matrix somewhere.
 //
 // If the value passed in is not recognized, it returns an InferMatrixError.
 func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
@@ -204,8 +205,8 @@ func (mat *MatMxN) InferMatrix(m interface{}) (*MatMxN, error) {
 	}
 }
 
-// Returns the trace of a square matrix (sum of all diagonal elements). If the matrix
-// is nil, or not square, the result will be NaN.
+// Trace returns the trace of a square matrix (sum of all diagonal elements). If
+// the matrix is nil, or not square, the result will be NaN.
 func (mat *MatMxN) Trace() float64 {
 	if mat == nil || mat.m != mat.n {
 		return float64(math.NaN())
@@ -219,7 +220,7 @@ func (mat *MatMxN) Trace() float64 {
 	return out
 }
 
-// Takes the transpose of mat and puts it in dst.
+// Transpose takes the transpose of mat and puts it in dst.
 //
 // If dst is not of the correct dimensions, it will be Reshaped,
 // if dst and mat are the same, a temporary matrix of the correct size will
@@ -261,7 +262,7 @@ func (mat *MatMxN) Transpose(dst *MatMxN) (t *MatMxN) {
 	return dst
 }
 
-// Returns the raw slice backing this matrix
+// Raw returns the raw slice backing this matrix
 func (mat *MatMxN) Raw() []float64 {
 	if mat == nil {
 		return nil
@@ -270,23 +271,23 @@ func (mat *MatMxN) Raw() []float64 {
 	return mat.dat
 }
 
-// Returns the number of rows in this matrix
+// NumRows returns the number of rows in this matrix
 func (mat *MatMxN) NumRows() int {
 	return mat.m
 }
 
-// Returns the number of columns in this matrix
+// NumCols returns the number of columns in this matrix
 func (mat *MatMxN) NumCols() int {
 	return mat.n
 }
 
-// Returns the number of rows and columns in this matrix
+// NumRowCols returns the number of rows and columns in this matrix
 // as a single operation
 func (mat *MatMxN) NumRowCols() (rows, cols int) {
 	return mat.m, mat.n
 }
 
-// Returns the element at the given row and column.
+// At returns the element at the given row and column.
 // This is garbage in/garbage out and does no bounds
 // checking. If the computation happens to lead to an invalid
 // element, it will be returned; or it may panic.
@@ -294,7 +295,7 @@ func (mat *MatMxN) At(row, col int) float64 {
 	return mat.dat[col*mat.m+row]
 }
 
-// Sets the element at the given row and column.
+// Set sets the element at the given row and column.
 // This is garbage in/garbage out and does no bounds
 // checking. If the computation happens to lead to an invalid
 // element, it will be set; or it may panic.
@@ -302,6 +303,7 @@ func (mat *MatMxN) Set(row, col int, val float64) {
 	mat.dat[col*mat.m+row] = val
 }
 
+// Add is the arithemtic + operator defined on a MatMxN.
 func (mat *MatMxN) Add(dst *MatMxN, addend *MatMxN) *MatMxN {
 	if mat == nil || addend == nil || mat.m != addend.m || mat.n != addend.n {
 		return nil
@@ -318,6 +320,7 @@ func (mat *MatMxN) Add(dst *MatMxN, addend *MatMxN) *MatMxN {
 	return dst
 }
 
+// Sub is the arithemtic - operator defined on a MatMxN.
 func (mat *MatMxN) Sub(dst *MatMxN, subtrahend *MatMxN) *MatMxN {
 	if mat == nil || subtrahend == nil || mat.m != subtrahend.m || mat.n != subtrahend.n {
 		return nil
@@ -334,13 +337,14 @@ func (mat *MatMxN) Sub(dst *MatMxN, subtrahend *MatMxN) *MatMxN {
 	return dst
 }
 
-// Performs matrix multiplication on MxN matrix mat and NxO matrix mul, storing the result in dst.
-// This returns dst, or nil if the operation is not able to be performed.
+// MulMxN performs matrix multiplication on MxN matrix mat and NxO matrix mul,
+// storing the result in dst. This returns dst, or nil if the operation is not
+// able to be performed.
 //
 // If mat == dst, or mul == dst a temporary matrix will be used.
 //
-// This uses the naive algorithm (though on smaller matrices,
-// this can actually be faster; about len(mat)+len(mul) < ~100)
+// This uses the naive algorithm (though on smaller matrices, this can actually
+// be faster; about len(mat)+len(mul) < ~100)
 func (mat *MatMxN) MulMxN(dst *MatMxN, mul *MatMxN) *MatMxN {
 	if mat == nil || mul == nil || mat.n != mul.m {
 		return nil
@@ -379,7 +383,7 @@ func (mat *MatMxN) MulMxN(dst *MatMxN, mul *MatMxN) *MatMxN {
 	return dst
 }
 
-// Performs a scalar multiplication between mat and some constant c,
+// Mul performs a scalar multiplication between mat and some constant c,
 // storing the result in dst. Mat and dst can be equal. If dst is not the
 // correct size, a Reshape will occur.
 func (mat *MatMxN) Mul(dst *MatMxN, c float64) *MatMxN {
@@ -396,12 +400,12 @@ func (mat *MatMxN) Mul(dst *MatMxN, c float64) *MatMxN {
 	return dst
 }
 
-// Multiplies the matrix by a vector of size n. If mat or v is
-// nil, this returns nil. If the number of columns in mat does not match
-// the Size of v, this also returns nil.
+// MulNx1 multiplies the matrix by a vector of size n. If mat or v is nil, this
+// returns nil. If the number of columns in mat does not match the Size of v,
+// this also returns nil.
 //
-// Dst will be resized if it's not big enough. If dst == v; a temporary
-// vector will be allocated and returned via the realloc callback when complete.
+// Dst will be resized if it's not big enough. If dst == v; a temporary vector
+// will be allocated and returned via the realloc callback when complete.
 func (mat *MatMxN) MulNx1(dst, v *VecN) *VecN {
 	if mat == nil || v == nil || mat.n != len(v.vec) {
 		return nil
@@ -426,6 +430,8 @@ func (mat *MatMxN) MulNx1(dst, v *VecN) *VecN {
 	return dst
 }
 
+// ApproxEqual returns whether the two vectors are approximately equal (See
+// FloatEqual).
 func (mat *MatMxN) ApproxEqual(m2 *MatMxN) bool {
 	if mat == m2 {
 		return true
@@ -443,6 +449,8 @@ func (mat *MatMxN) ApproxEqual(m2 *MatMxN) bool {
 	return true
 }
 
+// ApproxEqualThreshold returns whether the two vectors are approximately equal
+// to within the given threshold given by "epsilon" (See ApproxEqualThreshold).
 func (mat *MatMxN) ApproxEqualThreshold(m2 *MatMxN, epsilon float64) bool {
 	if mat == m2 {
 		return true
@@ -460,6 +468,8 @@ func (mat *MatMxN) ApproxEqualThreshold(m2 *MatMxN, epsilon float64) bool {
 	return true
 }
 
+// ApproxEqualFunc returns whether the two vectors are approximately equal,
+// given a function which compares two scalar elements.
 func (mat *MatMxN) ApproxEqualFunc(m2 *MatMxN, comp func(float64, float64) bool) bool {
 	if mat == m2 {
 		return true
@@ -477,18 +487,25 @@ func (mat *MatMxN) ApproxEqualFunc(m2 *MatMxN, comp func(float64, float64) bool)
 	return true
 }
 
+// InferMatrixError may be returned by InferMatrix.
+//
+// Make sure you're using a constant matrix such as Mat3 from within the same
+// package (meaning: mgl32.MatMxN can't handle a mgl64.Mat2x3).
 type InferMatrixError struct{}
 
 func (me InferMatrixError) Error() string {
 	return "could not infer matrix. Make sure you're using a constant matrix such as Mat3 from within the same package (meaning: mgl32.MatMxN can't handle a mgl64.Mat2x3)."
 }
 
+// RectangularMatrixError is returned when a rectangular matrix was expected but
+// not given.
 type RectangularMatrixError struct{}
 
 func (mse RectangularMatrixError) Error() string {
 	return "the matrix was the wrong shape, needed a square matrix."
 }
 
+// NilMatrixError is returned when an operand to a function was unexpectedly 'nil'.
 type NilMatrixError struct{}
 
 func (me NilMatrixError) Error() string {

--- a/mgl64/matrix.go
+++ b/mgl64/matrix.go
@@ -81,12 +81,12 @@ func (m Mat4) Mat3() Mat3 {
 	)
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat2) SetRow(row int, v Vec2) {
 	m[row+0], m[row+2] = v[0], v[1]
 }
@@ -213,7 +213,7 @@ func (m1 Mat2) Transpose() Mat2 {
 	return Mat2{m1[0], m1[2], m1[1], m1[3]}
 }
 
-// The determinant of a matrix is a measure of a square matrix's
+// Det returns the determinant of a matrix. It is a measure of a square matrix's
 // singularity and invertability, among other things. In this library, the
 // determinant is hard coded based on pre-computed cofactor expansion, and uses
 // no loops. Of course, the addition and multiplication must still be done.
@@ -266,7 +266,7 @@ func (m1 Mat2) ApproxEqualThreshold(m2 Mat2, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2) ApproxFuncEqual(m2 Mat2, eq func(float64, float64) bool) bool {
@@ -360,12 +360,12 @@ func (m Mat2) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x3) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x3) SetRow(row int, v Vec3) {
 	m[row+0], m[row+2], m[row+4] = v[0], v[1], v[2]
 }
@@ -490,7 +490,7 @@ func (m1 Mat2x3) ApproxEqualThreshold(m2 Mat2x3, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x3) ApproxFuncEqual(m2 Mat2x3, eq func(float64, float64) bool) bool {
@@ -578,12 +578,12 @@ func (m Mat2x3) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x4) SetCol(col int, v Vec2) {
 	m[col*2+0], m[col*2+1] = v[0], v[1]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat2x4) SetRow(row int, v Vec4) {
 	m[row+0], m[row+2], m[row+4], m[row+6] = v[0], v[1], v[2], v[3]
 }
@@ -708,7 +708,7 @@ func (m1 Mat2x4) ApproxEqualThreshold(m2 Mat2x4, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat2x4) ApproxFuncEqual(m2 Mat2x4, eq func(float64, float64) bool) bool {
@@ -796,12 +796,12 @@ func (m Mat2x4) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x2) SetCol(col int, v Vec3) {
 	m[col*3+0], m[col*3+1], m[col*3+2] = v[0], v[1], v[2]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x2) SetRow(row int, v Vec2) {
 	m[row+0], m[row+3] = v[0], v[1]
 }
@@ -936,7 +936,7 @@ func (m1 Mat3x2) ApproxEqualThreshold(m2 Mat3x2, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x2) ApproxFuncEqual(m2 Mat3x2, eq func(float64, float64) bool) bool {
@@ -1024,12 +1024,12 @@ func (m Mat3x2) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat3) SetCol(col int, v Vec3) {
 	m[col*3+0], m[col*3+1], m[col*3+2] = v[0], v[1], v[2]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat3) SetRow(row int, v Vec3) {
 	m[row+0], m[row+3], m[row+6] = v[0], v[1], v[2]
 }
@@ -1166,7 +1166,7 @@ func (m1 Mat3) Transpose() Mat3 {
 	return Mat3{m1[0], m1[3], m1[6], m1[1], m1[4], m1[7], m1[2], m1[5], m1[8]}
 }
 
-// The determinant of a matrix is a measure of a square matrix's
+// Det returns the determinant of a matrix. It is a measure of a square matrix's
 // singularity and invertability, among other things. In this library, the
 // determinant is hard coded based on pre-computed cofactor expansion, and uses
 // no loops. Of course, the addition and multiplication must still be done.
@@ -1229,7 +1229,7 @@ func (m1 Mat3) ApproxEqualThreshold(m2 Mat3, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3) ApproxFuncEqual(m2 Mat3, eq func(float64, float64) bool) bool {
@@ -1323,12 +1323,12 @@ func (m Mat3) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x4) SetCol(col int, v Vec3) {
 	m[col*3+0], m[col*3+1], m[col*3+2] = v[0], v[1], v[2]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat3x4) SetRow(row int, v Vec4) {
 	m[row+0], m[row+3], m[row+6], m[row+9] = v[0], v[1], v[2], v[3]
 }
@@ -1463,7 +1463,7 @@ func (m1 Mat3x4) ApproxEqualThreshold(m2 Mat3x4, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat3x4) ApproxFuncEqual(m2 Mat3x4, eq func(float64, float64) bool) bool {
@@ -1551,12 +1551,12 @@ func (m Mat3x4) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x2) SetCol(col int, v Vec4) {
 	m[col*4+0], m[col*4+1], m[col*4+2], m[col*4+3] = v[0], v[1], v[2], v[3]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x2) SetRow(row int, v Vec2) {
 	m[row+0], m[row+4] = v[0], v[1]
 }
@@ -1701,7 +1701,7 @@ func (m1 Mat4x2) ApproxEqualThreshold(m2 Mat4x2, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x2) ApproxFuncEqual(m2 Mat4x2, eq func(float64, float64) bool) bool {
@@ -1789,12 +1789,12 @@ func (m Mat4x2) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x3) SetCol(col int, v Vec4) {
 	m[col*4+0], m[col*4+1], m[col*4+2], m[col*4+3] = v[0], v[1], v[2], v[3]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat4x3) SetRow(row int, v Vec3) {
 	m[row+0], m[row+4], m[row+8] = v[0], v[1], v[2]
 }
@@ -1939,7 +1939,7 @@ func (m1 Mat4x3) ApproxEqualThreshold(m2 Mat4x3, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4x3) ApproxFuncEqual(m2 Mat4x3, eq func(float64, float64) bool) bool {
@@ -2027,12 +2027,12 @@ func (m Mat4x3) String() string {
 	return buf.String()
 }
 
-// Sets a Column within the Matrix, so it mutates the calling matrix.
+// SetCol sets a Column within the Matrix, so it mutates the calling matrix.
 func (m *Mat4) SetCol(col int, v Vec4) {
 	m[col*4+0], m[col*4+1], m[col*4+2], m[col*4+3] = v[0], v[1], v[2], v[3]
 }
 
-// Sets a Row within the Matrix, so it mutates the calling matrix.
+// SetRow sets a Row within the Matrix, so it mutates the calling matrix.
 func (m *Mat4) SetRow(row int, v Vec4) {
 	m[row+0], m[row+4], m[row+8], m[row+12] = v[0], v[1], v[2], v[3]
 }
@@ -2179,7 +2179,7 @@ func (m1 Mat4) Transpose() Mat4 {
 	return Mat4{m1[0], m1[4], m1[8], m1[12], m1[1], m1[5], m1[9], m1[13], m1[2], m1[6], m1[10], m1[14], m1[3], m1[7], m1[11], m1[15]}
 }
 
-// The determinant of a matrix is a measure of a square matrix's
+// Det returns the determinant of a matrix. It is a measure of a square matrix's
 // singularity and invertability, among other things. In this library, the
 // determinant is hard coded based on pre-computed cofactor expansion, and uses
 // no loops. Of course, the addition and multiplication must still be done.
@@ -2249,7 +2249,7 @@ func (m1 Mat4) ApproxEqualThreshold(m2 Mat4, threshold float64) bool {
 	return true
 }
 
-// ApproxEqualFunc performs an element-wise approximate equality test between two matrices
+// ApproxFuncEqual performs an element-wise approximate equality test between two matrices
 // with a given equality functions, intended to be used with FloatEqualFunc; although and comparison
 // function may be used in practice.
 func (m1 Mat4) ApproxFuncEqual(m2 Mat4, eq func(float64, float64) bool) bool {

--- a/mgl64/matstack/matstack.go
+++ b/mgl64/matstack/matstack.go
@@ -17,13 +17,13 @@ func NewMatStack() *MatStack {
 	return &MatStack{mgl64.Ident4()}
 }
 
-// Copies the top element and pushes it on the stack.
+// Push copies the top element and pushes it on the stack.
 func (ms *MatStack) Push() {
 	(*ms) = append(*ms, (*ms)[len(*ms)-1])
 }
 
-// Removes the first element of the matrix from the stack, if there is only one element left
-// there is an error.
+// Pop removes the first element of the matrix from the stack, if there is only
+// one element left there is an error.
 func (ms *MatStack) Pop() error {
 	if len(*ms) == 1 {
 		return errors.New("Cannot pop from mat stack, at minimum stack length of 1")
@@ -33,29 +33,27 @@ func (ms *MatStack) Pop() error {
 	return nil
 }
 
-// Right multiplies the current top of the matrix by the
-// argument.
+// RightMul multiplies the current top of the matrix by the argument.
 func (ms *MatStack) RightMul(m mgl64.Mat4) {
 	(*ms)[len(*ms)-1] = (*ms)[len(*ms)-1].Mul4(m)
 }
 
-// Left multiplies the current top of the matrix by the
-// argument.
+// LeftMul multiplies the current top of the matrix by the argument.
 func (ms *MatStack) LeftMul(m mgl64.Mat4) {
 	(*ms)[len(*ms)-1] = m.Mul4((*ms)[len(*ms)-1])
 }
 
-// Returns the top element.
+// Peek returns the top element.
 func (ms *MatStack) Peek() mgl64.Mat4 {
 	return (*ms)[len(*ms)-1]
 }
 
-// Rewrites the top element of the stack with m
+// Load rewrites the top element of the stack with m
 func (ms *MatStack) Load(m mgl64.Mat4) {
 	(*ms)[len(*ms)-1] = m
 }
 
-// A shortcut for Load(mgl.Ident4())
+// LoadIdent is a shortcut for Load(mgl.Ident4())
 func (ms *MatStack) LoadIdent() {
 	(*ms)[len(*ms)-1] = mgl64.Ident4()
 }

--- a/mgl64/matstack/transformStack.go
+++ b/mgl64/matstack/transformStack.go
@@ -9,16 +9,19 @@ import (
 	"github.com/go-gl/mathgl/mgl64"
 )
 
-// A transform stack is a linear fully-persistent data structure of matrix multiplications
-// Each push to a TransformStack multiplies the current top of the stack with thew new matrix
-// and appends it to the top. Each pop undoes the previous multiplication.
+// TransformStack is a linear fully-persistent data structure of matrix
+// multiplications Each push to a TransformStack multiplies the current top of
+// the stack with thew new matrix and appends it to the top. Each pop undoes the
+// previous multiplication.
 //
-// This allows arbitrary unwinding of transformations, at the cost of a lot of memory. A notable feature
-// is the reseed and rebase, which allow invertible transformations to be rewritten as if a different transform
-// had been made in the middle.
+// This allows arbitrary unwinding of transformations, at the cost of a lot of
+// memory. A notable feature is the reseed and rebase, which allow invertible
+// transformations to be rewritten as if a different transform had been made in
+// the middle.
 type TransformStack []mgl64.Mat4
 
-// Returns a matrix stack where the top element is the identity.
+// NewTransformStack returns a matrix stack where the top element is the
+// identity.
 func NewTransformStack() *TransformStack {
 	ms := make(TransformStack, 1)
 	ms[0] = mgl64.Ident4()
@@ -26,15 +29,15 @@ func NewTransformStack() *TransformStack {
 	return &ms
 }
 
-// Multiplies the current top matrix by m, and pushes the result
-// on the stack.
+// Push multiplies the current top matrix by m, and pushes the result on the
+// stack.
 func (ms *TransformStack) Push(m mgl64.Mat4) {
 	prev := (*ms)[len(*ms)-1]
 	(*ms) = append(*ms, prev.Mul4(m))
 }
 
-// Pops the current matrix off the top of the stack and returns it.
-// If the matrix stack only has one element left, this will return an error.
+// Pop the current matrix off the top of the stack and returns it. If the matrix
+// stack only has one element left, this will return an error.
 func (ms *TransformStack) Pop() (mgl64.Mat4, error) {
 	if len(*ms) == 1 {
 		return mgl64.Mat4{}, errors.New("attempt to pop last element of the stack; Matrix Stack must have at least one element")
@@ -47,20 +50,21 @@ func (ms *TransformStack) Pop() (mgl64.Mat4, error) {
 	return retVal, nil
 }
 
-// Returns the value of the current top element of the stack, without
+// Peek returns the value of the current top element of the stack, without
 // removing it.
 func (ms *TransformStack) Peek() mgl64.Mat4 {
 	return (*ms)[len(*ms)-1]
 }
 
-// Returns the size of the matrix stack. This value will never be less
+// Len returns the size of the matrix stack. This value will never be less
 // than 1.
 func (ms *TransformStack) Len() int {
 	return len(*ms)
 }
 
-// This cuts down the matrix as if Pop had been called n times. If n would
-// bring the matrix down below 1 element, this does nothing and returns an error.
+// Unwind cuts down the matrix as if Pop had been called n times. If n would
+// bring the matrix down below 1 element, this does nothing and returns an
+// error.
 func (ms *TransformStack) Unwind(n int) error {
 	if n > len(*ms)-1 {
 		return errors.New("Cannot unwind a matrix to below 1 value")
@@ -70,9 +74,9 @@ func (ms *TransformStack) Unwind(n int) error {
 	return nil
 }
 
-// Copy will create a new "branch" of the current matrix stack,
-// the copy will contain all elements of the current stack in a new stack. Changes to
-// one will never affect the other.
+// Copy will create a new "branch" of the current matrix stack, the copy will
+// contain all elements of the current stack in a new stack. Changes to one will
+// never affect the other.
 func (ms *TransformStack) Copy() *TransformStack {
 	v := append(TransformStack{}, (*ms)...)
 	return &v

--- a/mgl64/project.go
+++ b/mgl64/project.go
@@ -11,17 +11,20 @@ import (
 	"math"
 )
 
+// Ortho generates an Ortho Matrix.
 func Ortho(left, right, bottom, top, near, far float64) Mat4 {
 	rml, tmb, fmn := (right - left), (top - bottom), (far - near)
 
 	return Mat4{float64(2. / rml), 0, 0, 0, 0, float64(2. / tmb), 0, 0, 0, 0, float64(-2. / fmn), 0, float64(-(right + left) / rml), float64(-(top + bottom) / tmb), float64(-(far + near) / fmn), 1}
 }
 
-// Equivalent to Ortho with the near and far planes being -1 and 1, respectively
+// Ortho2D is equivalent to Ortho with the near and far planes being -1 and 1,
+// respectively.
 func Ortho2D(left, right, bottom, top float64) Mat4 {
 	return Ortho(left, right, bottom, top, -1, 1)
 }
 
+// Perspective generates a Perspective Matrix.
 func Perspective(fovy, aspect, near, far float64) Mat4 {
 	// fovy = (fovy * math.Pi) / 180.0 // convert from degrees to radians
 	nmf, f := near-far, float64(1./math.Tan(float64(fovy)/2.0))
@@ -29,6 +32,7 @@ func Perspective(fovy, aspect, near, far float64) Mat4 {
 	return Mat4{float64(f / aspect), 0, 0, 0, 0, float64(f), 0, 0, 0, 0, float64((near + far) / nmf), -1, 0, 0, float64((2. * far * near) / nmf), 0}
 }
 
+// Frustum generates a Frustum Matrix.
 func Frustum(left, right, bottom, top, near, far float64) Mat4 {
 	rml, tmb, fmn := (right - left), (top - bottom), (far - near)
 	A, B, C, D := (right+left)/rml, (top+bottom)/tmb, -(far+near)/fmn, -(2*far*near)/fmn
@@ -36,11 +40,13 @@ func Frustum(left, right, bottom, top, near, far float64) Mat4 {
 	return Mat4{float64((2. * near) / rml), 0, 0, 0, 0, float64((2. * near) / tmb), 0, 0, float64(A), float64(B), float64(C), -1, 0, 0, float64(D), 0}
 }
 
+// LookAt generates a transform matrix from world space to the given eye space.
 func LookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ float64) Mat4 {
 	return LookAtV(Vec3{eyeX, eyeY, eyeZ}, Vec3{centerX, centerY, centerZ}, Vec3{upX, upY, upZ})
 }
 
-//  LookAtV generates a transform matrix from world space into the specific eye space
+// LookAtV generates a transform matrix from world space into the specific eye
+// space.
 func LookAtV(eye, center, up Vec3) Mat4 {
 	f := center.Sub(eye).Normalize()
 	s := f.Cross(up.Normalize()).Normalize()
@@ -56,10 +62,12 @@ func LookAtV(eye, center, up Vec3) Mat4 {
 	return M.Mul4(Translate3D(float64(-eye[0]), float64(-eye[1]), float64(-eye[2])))
 }
 
-// Transform a set of coordinates from object space (in obj) to window coordinates (with depth)
+// Project transforms a set of coordinates from object space (in obj) to window
+// coordinates (with depth).
 //
-// Window coordinates are continuous, not discrete (well, as continuous as an IEEE Floating Point can be), so you won't get exact pixel locations
-// without rounding or similar
+// Window coordinates are continuous, not discrete (well, as continuous as an
+// IEEE Floating Point can be), so you won't get exact pixel locations without
+// rounding or similar
 func Project(obj Vec3, modelview, projection Mat4, initialX, initialY, width, height int) (win Vec3) {
 	obj4 := obj.Vec4(1)
 
@@ -72,10 +80,13 @@ func Project(obj Vec3, modelview, projection Mat4, initialX, initialY, width, he
 	return win
 }
 
-// Transform a set of window coordinates to object space. If your MVP (projection.Mul(modelview) matrix is not invertible, this will return an error
+// UnProject transforms a set of window coordinates to object space. If your MVP
+// (projection.Mul(modelview) matrix is not invertible, this will return an
+// error.
 //
-// Note that the projection may not be perfect if you use strict pixel locations rather than the exact values given by Projectf.
-// (It's still unlikely to be perfect due to precision errors, but it will be closer)
+// Note that the projection may not be perfect if you use strict pixel locations
+// rather than the exact values given by Projectf. (It's still unlikely to be
+// perfect due to precision errors, but it will be closer)
 func UnProject(win Vec3, modelview, projection Mat4, initialX, initialY, width, height int) (obj Vec3, err error) {
 	inv := projection.Mul4(modelview).Inv()
 	var blank Mat4

--- a/mgl64/quat.go
+++ b/mgl64/quat.go
@@ -10,10 +10,12 @@ import (
 	"math"
 )
 
-// A rotation order is the order in which
-// rotations will be transformed for the purposes of AnglesToQuat
+// RotationOrder is the order in which rotations will be transformed for the
+// purposes of AnglesToQuat.
 type RotationOrder int
 
+// The RotationOrder constants represent a series of rotations along the given
+// axes for the use of AnglesToQuat.
 const (
 	XYX RotationOrder = iota
 	XYZ
@@ -29,20 +31,20 @@ const (
 	ZXY
 )
 
-// A Quaternion is an extension of the imaginary numbers; there's all sorts of
-// interesting theory behind it. In 3D graphics we mostly use it as a cheap way of
-// representing rotation since quaternions are cheaper to multiply by, and easier to
-// interpolate than matrices.
+// Quat represents a Quaternion, which is an extension of the imaginary numbers;
+// there's all sorts of interesting theory behind it. In 3D graphics we mostly
+// use it as a cheap way of representing rotation since quaternions are cheaper
+// to multiply by, and easier to interpolate than matrices.
 //
-// A Quaternion has two parts: W, the so-called scalar component,
-// and "V", the vector component. The vector component is considered to
-// be the part in 3D space, while W (loosely interpreted) is its 4D coordinate.
+// A Quaternion has two parts: W, the so-called scalar component, and "V", the
+// vector component. The vector component is considered to be the part in 3D
+// space, while W (loosely interpreted) is its 4D coordinate.
 type Quat struct {
 	W float64
 	V Vec3
 }
 
-// The quaternion identity: W=1; V=(0,0,0).
+// QuatIdent returns the quaternion identity: W=1; V=(0,0,0).
 //
 // As with all identities, multiplying any quaternion by this will yield the same
 // quaternion you started with.
@@ -50,7 +52,7 @@ func QuatIdent() Quat {
 	return Quat{1., Vec3{0, 0, 0}}
 }
 
-// Creates an angle from an axis and an angle relative to that axis.
+// QuatRotate creates an angle from an axis and an angle relative to that axis.
 //
 // This is cheaper than HomogRotate3D.
 func QuatRotate(angle float64, axis Vec3) Quat {
@@ -61,63 +63,63 @@ func QuatRotate(angle float64, axis Vec3) Quat {
 	return Quat{c, axis.Mul(s)}
 }
 
-// A convenient alias for q.V[0]
+// X is a convenient alias for q.V[0]
 func (q Quat) X() float64 {
 	return q.V[0]
 }
 
-// A convenient alias for q.V[1]
+// Y is a convenient alias for q.V[1]
 func (q Quat) Y() float64 {
 	return q.V[1]
 }
 
-// A convenient alias for q.V[2]
+// Z is a convenient alias for q.V[2]
 func (q Quat) Z() float64 {
 	return q.V[2]
 }
 
-// Adds two quaternions. It's no more complicated than
+// Add adds two quaternions. It's no more complicated than
 // adding their W and V components.
 func (q1 Quat) Add(q2 Quat) Quat {
 	return Quat{q1.W + q2.W, q1.V.Add(q2.V)}
 }
 
-// Subtracts two quaternions. It's no more complicated than
+// Sub subtracts two quaternions. It's no more complicated than
 // subtracting their W and V components.
 func (q1 Quat) Sub(q2 Quat) Quat {
 	return Quat{q1.W - q2.W, q1.V.Sub(q2.V)}
 }
 
-// Multiplies two quaternions. This can be seen as a rotation. Note that
+// Mul multiplies two quaternions. This can be seen as a rotation. Note that
 // Multiplication is NOT commutative, meaning q1.Mul(q2) does not necessarily
 // equal q2.Mul(q1).
 func (q1 Quat) Mul(q2 Quat) Quat {
 	return Quat{q1.W*q2.W - q1.V.Dot(q2.V), q1.V.Cross(q2.V).Add(q2.V.Mul(q1.W)).Add(q1.V.Mul(q2.W))}
 }
 
-// Scales every element of the quaternion by some constant factor.
+// Scale every element of the quaternion by some constant factor.
 func (q1 Quat) Scale(c float64) Quat {
 	return Quat{q1.W * c, Vec3{q1.V[0] * c, q1.V[1] * c, q1.V[2] * c}}
 }
 
-// Returns the conjugate of a quaternion. Equivalent to
-// Quat{q1.W, q1.V.Mul(-1)}
+// Conjugate returns the conjugate of a quaternion. Equivalent to
+// Quat{q1.W, q1.V.Mul(-1)}.
 func (q1 Quat) Conjugate() Quat {
 	return Quat{q1.W, q1.V.Mul(-1)}
 }
 
-// Returns the Length of the quaternion, also known as its Norm. This is the same thing as
-// the Len of a Vec4
+// Len gives the Length of the quaternion, also known as its Norm. This is the
+// same thing as the Len of a Vec4.
 func (q1 Quat) Len() float64 {
 	return float64(math.Sqrt(float64(q1.W*q1.W + q1.V[0]*q1.V[0] + q1.V[1]*q1.V[1] + q1.V[2]*q1.V[2])))
 }
 
-// Norm() is an alias for Len() since both are very common terms.
+// Norm is an alias for Len() since both are very common terms.
 func (q1 Quat) Norm() float64 {
 	return q1.Len()
 }
 
-// Normalizes the quaternion, returning its versor (unit quaternion).
+// Normalize the quaternion, returning its versor (unit quaternion).
 //
 // This is the same as normalizing it as a Vec4.
 func (q1 Quat) Normalize() Quat {
@@ -136,7 +138,7 @@ func (q1 Quat) Normalize() Quat {
 	return Quat{q1.W * 1 / length, q1.V.Mul(1 / length)}
 }
 
-// The inverse of a quaternion. The inverse is equivalent
+// Inverse of a quaternion. The inverse is equivalent
 // to the conjugate divided by the square of the length.
 //
 // This method computes the square norm by directly adding the sum
@@ -146,7 +148,7 @@ func (q1 Quat) Inverse() Quat {
 	return q1.Conjugate().Scale(1 / q1.Dot(q1))
 }
 
-// Rotates a vector by the rotation this quaternion represents.
+// Rotate a vector by the rotation this quaternion represents.
 // This will result in a 3D vector. Strictly speaking, this is
 // equivalent to q1.v.q* where the "."" is quaternion multiplication and v is interpreted
 // as a quaternion with W 0 and V v. In code:
@@ -161,7 +163,8 @@ func (q1 Quat) Rotate(v Vec3) Vec3 {
 	return v.Add(cross.Mul(2 * q1.W)).Add(q1.V.Mul(2).Cross(cross))
 }
 
-// Returns the homogeneous 3D rotation matrix corresponding to the quaternion.
+// Mat4 returns the homogeneous 3D rotation matrix corresponding to the
+// quaternion.
 func (q1 Quat) Mat4() Mat4 {
 	w, x, y, z := q1.W, q1.V[0], q1.V[1], q1.V[2]
 	return Mat4{
@@ -172,30 +175,30 @@ func (q1 Quat) Mat4() Mat4 {
 	}
 }
 
-// The dot product between two quaternions, equivalent to if this was a Vec4
+// Dot product between two quaternions, equivalent to if this was a Vec4.
 func (q1 Quat) Dot(q2 Quat) float64 {
 	return q1.W*q2.W + q1.V[0]*q2.V[0] + q1.V[1]*q2.V[1] + q1.V[2]*q2.V[2]
 }
 
-// Returns whether the quaternions are approximately equal, as if
+// ApproxEqual returns whether the quaternions are approximately equal, as if
 // FloatEqual was called on each matching element
 func (q1 Quat) ApproxEqual(q2 Quat) bool {
 	return FloatEqual(q1.W, q2.W) && q1.V.ApproxEqual(q2.V)
 }
 
-// Returns whether the quaternions are approximately equal with a given tolerence, as if
+// ApproxEqualThreshold returns whether the quaternions are approximately equal with a given tolerence, as if
 // FloatEqualThreshold was called on each matching element with the given epsilon
 func (q1 Quat) ApproxEqualThreshold(q2 Quat, epsilon float64) bool {
 	return FloatEqualThreshold(q1.W, q2.W, epsilon) && q1.V.ApproxEqualThreshold(q2.V, epsilon)
 }
 
-// Returns whether the quaternions are approximately equal using the given comparison function, as if
+// ApproxEqualFunc returns whether the quaternions are approximately equal using the given comparison function, as if
 // the function had been called on each individual element
 func (q1 Quat) ApproxEqualFunc(q2 Quat, f func(float64, float64) bool) bool {
 	return f(q1.W, q2.W) && q1.V.ApproxFuncEqual(q2.V, f)
 }
 
-// Returns whether the quaternions represents the same orientation
+// OrientationEqual returns whether the quaternions represents the same orientation
 //
 // Different values can represent the same orientation (q == -q) because quaternions avoid singularities
 // and discontinuities involved with rotation in 3 dimensions by adding extra dimensions
@@ -203,12 +206,12 @@ func (q1 Quat) OrientationEqual(q2 Quat) bool {
 	return q1.OrientationEqualThreshold(q2, Epsilon)
 }
 
-// Returns whether the quaternions represents the same orientation with a given tolerence
+// OrientationEqualThreshold returns whether the quaternions represents the same orientation with a given tolerence
 func (q1 Quat) OrientationEqualThreshold(q2 Quat, epsilon float64) bool {
 	return Abs(q1.Normalize().Dot(q2.Normalize())) > 1-epsilon
 }
 
-// Slerp is *S*pherical *L*inear Int*erp*olation, a method of interpolating
+// QuatSlerp is *S*pherical *L*inear Int*erp*olation, a method of interpolating
 // between two quaternions. This always takes the straightest path on the sphere between
 // the two quaternions, and maintains constant velocity.
 //
@@ -232,14 +235,14 @@ func QuatSlerp(q1, q2 Quat, amount float64) Quat {
 	return q1.Scale(c).Add(rel.Scale(s))
 }
 
-// *L*inear Int*erp*olation between two Quaternions, cheap and simple.
+// QuatLerp is a *L*inear Int*erp*olation between two Quaternions, cheap and simple.
 //
 // Not excessively useful, but uses can be found.
 func QuatLerp(q1, q2 Quat, amount float64) Quat {
 	return q1.Add(q2.Sub(q1).Scale(amount))
 }
 
-// *Normalized* *L*inear Int*erp*olation between two Quaternions. Cheaper than Slerp
+// QuatNlerp is a *Normalized* *L*inear Int*erp*olation between two Quaternions. Cheaper than Slerp
 // and usually just as good. This is literally Lerp with Normalize() called on it.
 //
 // Unlike Slerp, constant velocity isn't maintained, but it's much faster and
@@ -250,7 +253,7 @@ func QuatNlerp(q1, q2 Quat, amount float64) Quat {
 	return QuatLerp(q1, q2, amount).Normalize()
 }
 
-// Performs a rotation in the specified order. If the order is not
+// AnglesToQuat performs a rotation in the specified order. If the order is not
 // a valid RotationOrder, this function will panic
 //
 // The rotation "order" is more of an axis descriptor. For instance XZX would

--- a/mgl64/shapes.go
+++ b/mgl64/shapes.go
@@ -11,7 +11,7 @@ import (
 	"math"
 )
 
-// Generates a circle centered at (0,0) with a given radius.
+// Circle generates a circle centered at (0,0) with a given radius.
 // The radii are assumed to be in GL's coordinate sizing.
 //
 // Technically this draws an ellipse with two axes that match with the X and Y axes, the reason it has a radiusX and radiusY is because GL's coordinate system
@@ -45,7 +45,7 @@ func Circle(radiusX, radiusY float64, numSlices int) []Vec2 {
 	return circlePoints
 }
 
-// Generates a 2-triangle rectangle for use with GL_TRIANGLES. The width and height should use GL's proportions (that is, where a width of 1.0
+// Rect generates a 2-triangle rectangle for use with GL_TRIANGLES. The width and height should use GL's proportions (that is, where a width of 1.0
 // is equivalent to half of the width of the render target); however, the y-coordinates grow downwards, not upwards. That is, it
 // assumes you want the origin of the rectangle with the top-left corner at (0.0,0.0).
 //
@@ -64,6 +64,7 @@ func Rect(width, height float64) []Vec2 {
 	}
 }
 
+// QuadraticBezierCurve2D interpolates the point t on the given bezier curve.
 func QuadraticBezierCurve2D(t float64, cPoint1, cPoint2, cPoint3 Vec2) Vec2 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -72,6 +73,7 @@ func QuadraticBezierCurve2D(t float64, cPoint1, cPoint2, cPoint3 Vec2) Vec2 {
 	return cPoint1.Mul((1.0 - t) * (1.0 - t)).Add(cPoint2.Mul(2 * (1 - t) * t)).Add(cPoint3.Mul(t * t))
 }
 
+// QuadraticBezierCurve3D interpolates the point t on the given bezier curve.
 func QuadraticBezierCurve3D(t float64, cPoint1, cPoint2, cPoint3 Vec3) Vec3 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -80,6 +82,7 @@ func QuadraticBezierCurve3D(t float64, cPoint1, cPoint2, cPoint3 Vec3) Vec3 {
 	return cPoint1.Mul((1.0 - t) * (1.0 - t)).Add(cPoint2.Mul(2 * (1 - t) * t)).Add(cPoint3.Mul(t * t))
 }
 
+// CubicBezierCurve2D interpolates the point t on the given bezier curve.
 func CubicBezierCurve2D(t float64, cPoint1, cPoint2, cPoint3, cPoint4 Vec2) Vec2 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -88,6 +91,7 @@ func CubicBezierCurve2D(t float64, cPoint1, cPoint2, cPoint3, cPoint4 Vec2) Vec2
 	return cPoint1.Mul((1 - t) * (1 - t) * (1 - t)).Add(cPoint2.Mul(3 * (1 - t) * (1 - t) * t)).Add(cPoint3.Mul(3 * (1 - t) * t * t)).Add(cPoint4.Mul(t * t * t))
 }
 
+// CubicBezierCurve3D interpolates the point t on the given bezier curve.
 func CubicBezierCurve3D(t float64, cPoint1, cPoint2, cPoint3, cPoint4 Vec3) Vec3 {
 	if t < 0.0 || t > 1.0 {
 		panic("Can't interpolate on bezier curve with t out of range [0.0,1.0]")
@@ -96,7 +100,7 @@ func CubicBezierCurve3D(t float64, cPoint1, cPoint2, cPoint3, cPoint4 Vec3) Vec3
 	return cPoint1.Mul((1 - t) * (1 - t) * (1 - t)).Add(cPoint2.Mul(3 * (1 - t) * (1 - t) * t)).Add(cPoint3.Mul(3 * (1 - t) * t * t)).Add(cPoint4.Mul(t * t * t))
 }
 
-// Returns the point at point t along an n-control point Bezier curve
+// BezierCurve2D returns the point at point t along an n-control point Bezier curve
 //
 // t must be in the range 0.0 and 1.0 or this function will panic. Consider [0.0,1.0] to be similar to a percentage,
 // 0.0 is first control point, and the point at 1.0 is the last control point. Any point in between is how far along the path you are between 0 and 1.
@@ -118,7 +122,7 @@ func BezierCurve2D(t float64, cPoints []Vec2) Vec2 {
 	return point
 }
 
-// Same as the 2D version, except the line is in 3D space
+// BezierCurve3D same as the 2D version, except the line is in 3D space
 func BezierCurve3D(t float64, cPoints []Vec3) Vec3 {
 	if t < 0.0 || t > 1.0 {
 		panic("Input to bezier has t not in range [0,1]. If you think this is a precision error, use mathgl.Clamp[f|d] before calling this function")
@@ -134,13 +138,16 @@ func BezierCurve3D(t float64, cPoints []Vec3) Vec3 {
 	return point
 }
 
-// Generates a bezier curve with controlPoints cPoints. The numPoints argument
-// determines how many "samples" it makes along the line. For instance, a
-// call to this with numPoints 2 will have exactly two points: the start and end points
-// For any points above 2 it will divide it into numPoints-1 chunks (which means it will generate numPoints-2 vertices other than the beginning and end).
-// So for 3 points it will divide it in half, 4 points into thirds, and so on.
+// MakeBezierCurve2D generates a bezier curve with controlPoints cPoints. The
+// numPoints argument determines how many "samples" it makes along the line. For
+// instance, a call to this with numPoints 2 will have exactly two points: the
+// start and end points For any points above 2 it will divide it into
+// numPoints-1 chunks (which means it will generate numPoints-2 vertices other
+// than the beginning and end). So for 3 points it will divide it in half, 4
+// points into thirds, and so on.
 //
-// This is likely to get rather expensive for anything over perhaps a cubic curve.
+// This is likely to get rather expensive for anything over perhaps a cubic
+// curve.
 func MakeBezierCurve2D(numPoints int, cPoints []Vec2) (line []Vec2) {
 	line = make([]Vec2, numPoints)
 	if numPoints == 0 {
@@ -163,7 +170,7 @@ func MakeBezierCurve2D(numPoints int, cPoints []Vec2) (line []Vec2) {
 	return
 }
 
-// Same as the 2D version, except with the line in 3D space
+// MakeBezierCurve3D same as the 2D version, except with the line in 3D space.
 func MakeBezierCurve3D(numPoints int, cPoints []Vec3) (line []Vec3) {
 	line = make([]Vec3, numPoints)
 	if numPoints == 0 {
@@ -186,11 +193,12 @@ func MakeBezierCurve3D(numPoints int, cPoints []Vec3) (line []Vec3) {
 	return
 }
 
-// Creates a 2-dimensional Bezier surface of arbitrary degree in 3D Space
-// Like the curve functions, if u or v are not in the range [0.0,1.0] the function will panic, use Clamp[f|d]
-// to ensure it is correct.
+// BezierSurface creates a 2-dimensional Bezier surface of arbitrary degree in
+// 3D Space Like the curve functions, if u or v are not in the range [0.0,1.0]
+// the function will panic, use Clamp[f|d] to ensure it is correct.
 //
-// The control point matrix must not be jagged, or this will end up panicking from an index out of bounds exception
+// The control point matrix must not be jagged, or this will end up panicking
+// from an index out of bounds exception
 func BezierSurface(u, v float64, cPoints [][]Vec3) Vec3 {
 	if u < 0.0 || u > 1.0 || v < 1.0 || v > 1.0 {
 		panic("u or v not in range [0.0,1.0] in BezierSurface")
@@ -214,8 +222,9 @@ func BezierSurface(u, v float64, cPoints [][]Vec3) Vec3 {
 	return point
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
-// though the spline may be disjoint. The bezier curves are not required to be in any particular order.
+// BezierSplineInterpolate2D does interpolation over a spline of several bezier
+// curves. Each bezier curve must have a finite range, though the spline may be
+// disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic
 func BezierSplineInterpolate2D(t float64, ranges [][2]float64, cPoints [][]Vec2) Vec2 {
@@ -232,8 +241,9 @@ func BezierSplineInterpolate2D(t float64, ranges [][2]float64, cPoints [][]Vec2)
 	panic("t is out of the range of all bezier curves in this spline")
 }
 
-// Does interpolation over a spline of several bezier curves. Each bezier curve must have a finite range,
-// though the spline may be disjoint. The bezier curves are not required to be in any particular order.
+// BezierSplineInterpolate3D does interpolation over a spline of several bezier
+// curves. Each bezier curve must have a finite range, though the spline may be
+// disjoint. The bezier curves are not required to be in any particular order.
 //
 // If t is out of the range of all given curves, this function will panic
 func BezierSplineInterpolate3D(t float64, ranges [][2]float64, cPoints [][]Vec3) Vec3 {
@@ -250,7 +260,7 @@ func BezierSplineInterpolate3D(t float64, ranges [][2]float64, cPoints [][]Vec3)
 	panic("t is out of the range of all bezier curves in this spline")
 }
 
-// Reticulates ALL the Splines
+// ReticulateSplines reticulates ALL the Splines.
 //
 // For the overly serious: the function is just for fun. It does nothing except prints a Maxis reference. Technically you could "reticulate splines"
 // by joining a bunch of splines together, but that ruins the joke.
@@ -262,7 +272,7 @@ func ReticulateSplines(ranges [][][2]float64, cPoints [][][]Vec2, withLlamas boo
 	}
 }
 
-// Transform from pixel coordinates to GL coordinates.
+// ScreenToGLCoords transforms from pixel coordinates to GL coordinates.
 //
 // This assumes that your pixel coordinate system considers its origin to be in the top left corner (GL's is in the bottom left).
 // The coordinates x and y may be out of the range [0,screenWidth-1] and [0,screeneHeight-1].
@@ -278,7 +288,7 @@ func ScreenToGLCoords(x, y int, screenWidth, screenHeight int) (xOut, yOut float
 	return
 }
 
-// Transform from GL's proportional system to pixel coordinates.
+// GLToScreenCoords transforms from GL's proportional system to pixel coordinates.
 //
 // Assumes the pixel coordinate system has its origin in the top left corner. (GL's is in the bottom left)
 //

--- a/mgl64/transform.go
+++ b/mgl64/transform.go
@@ -76,14 +76,14 @@ func Translate3D(Tx, Ty, Tz float64) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, float64(Tx), float64(Ty), float64(Tz), 1}
 }
 
-// Same as Rotate2D, except homogeneous (3x3 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate2D is the same as Rotate2D, except homogeneous (3x3 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate2D(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
-// Same as Rotate3DX, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate3DX is the same as Rotate3DX, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DX(angle float64) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
@@ -91,14 +91,14 @@ func HomogRotate3DX(angle float64) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, cos, sin, 0, 0, -sin, cos, 0, 0, 0, 0, 1}
 }
 
-// Same as Rotate3DY, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate3DY is the same as Rotate3DY, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DY(angle float64) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
 	return Mat4{cos, 0, -sin, 0, 0, 1, 0, 0, sin, 0, cos, 0, 0, 0, 0, 1}
 }
 
-// Same as Rotate3DZ, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
+// HomogRotate3DZ is the same as Rotate3DZ, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DZ(angle float64) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
@@ -166,14 +166,14 @@ func HomogRotate3D(angle float64, axis Vec3) Mat4 {
 	return Mat4{x*x*k + c, x*y*k + z*s, x*z*k - y*s, 0, x*y*k - z*s, y*y*k + c, y*z*k + x*s, 0, x*z*k + y*s, y*z*k - x*s, z*z*k + c, 0, 0, 0, 0, 1}
 }
 
-// Extracts the 3d scaling from a homogeneous matrix
+// Extract3DScale extracts the 3d scaling from a homogeneous matrix
 func Extract3DScale(m Mat4) (x, y, z float64) {
 	return float64(math.Sqrt(float64(m[0]*m[0] + m[1]*m[1] + m[2]*m[2]))),
 		float64(math.Sqrt(float64(m[4]*m[4] + m[5]*m[5] + m[6]*m[6]))),
 		float64(math.Sqrt(float64(m[8]*m[8] + m[9]*m[9] + m[10]*m[10])))
 }
 
-// Extracts the maximum scaling from a homogeneous matrix
+// ExtractMaxScale extracts the maximum scaling from a homogeneous matrix
 func ExtractMaxScale(m Mat4) float64 {
 	scaleX := float64(m[0]*m[0] + m[1]*m[1] + m[2]*m[2])
 	scaleY := float64(m[4]*m[4] + m[5]*m[5] + m[6]*m[6])
@@ -182,13 +182,13 @@ func ExtractMaxScale(m Mat4) float64 {
 	return float64(math.Sqrt(math.Max(scaleX, math.Max(scaleY, scaleZ))))
 }
 
-// Calculates the Normal of the Matrix (aka the inverse transpose)
+// Mat4Normal calculates the Normal of the Matrix (aka the inverse transpose)
 func Mat4Normal(m Mat4) Mat3 {
 	n := m.Inv().Transpose()
 	return Mat3{n[0], n[1], n[2], n[4], n[5], n[6], n[8], n[9], n[10]}
 }
 
-// Multiplies a 3D vector by a transformation given by
+// TransformCoordinate multiplies a 3D vector by a transformation given by
 // the homogeneous 4D matrix m, applying any translation.
 // If this transformation is non-affine, it will project this
 // vector onto the plane w=1 before returning the result.
@@ -207,7 +207,7 @@ func TransformCoordinate(v Vec3, m Mat4) Vec3 {
 	return t.Vec3()
 }
 
-// Multiplies a 3D vector by a transformation given by
+// TransformNormal multiplies a 3D vector by a transformation given by
 // the homogeneous 4D matrix m, NOT applying any translations.
 //
 // This is similar to saying you're applying a transformation

--- a/mgl64/util.go
+++ b/mgl64/util.go
@@ -23,7 +23,7 @@ import (
 // are being executed when you change this.
 var Epsilon float64 = 1e-10
 
-// A direct copy of the math package's Abs. This is here for the mgl32
+// Abs is a direct copy of the math package's Abs. This is here for the mgl32
 // package, to prevent rampant type conversions during equality tests.
 func Abs(a float64) float64 {
 	if a < 0 {
@@ -52,6 +52,7 @@ func FloatEqualFunc(epsilon float64) func(float64, float64) bool {
 	}
 }
 
+// Various useful constants.
 var (
 	MinNormal = float64(1.1754943508222875e-38) // 1 / 2**(127 - 1)
 	MinValue  = float64(math.SmallestNonzeroFloat64)
@@ -106,26 +107,27 @@ func ClampFunc(low, high float64) func(float64) float64 {
 	}
 }
 
-/* The IsClamped functions use strict equality (meaning: not the FloatEqual function)
-there shouldn't be any major issues with this since clamp is often used to fix minor errors*/
-
-// Checks if a is clamped between low and high as if
+// IsClamped checks if a is clamped between low and high as if
 // Clamp(a, low, high) had been called.
 //
 // In most cases it's probably better to just call Clamp
 // without checking this since it's relatively cheap.
+//
+// The IsClamped functions use strict equality (meaning: not the FloatEqual
+// function) there shouldn't be any major issues with this since clamp is often
+// used to fix minor errors
 func IsClamped(a, low, high float64) bool {
 	return a >= low && a <= high
 }
 
-// If a > b, then a will be set to the value of b.
+// SetMin sets a to b if a > b.
 func SetMin(a, b *float64) {
 	if *b < *a {
 		*a = *b
 	}
 }
 
-// If a < b, then a will be set to the value of b.
+// SetMax sets a to b if a < b.
 func SetMax(a, b *float64) {
 	if *a < *b {
 		*a = *b

--- a/mgl64/vecn.go
+++ b/mgl64/vecn.go
@@ -10,7 +10,7 @@ import (
 	"math"
 )
 
-// A vector of N elements backed by a slice
+// VecN represents a vector of N elements backed by a slice.
 //
 // As with MatMxN, this is not for hardcore linear algebra with large dimensions. Use github.com/gonum/matrix
 // or something like BLAS/LAPACK for that. This is for corner cases in 3D math where you require
@@ -23,7 +23,7 @@ type VecN struct {
 	vec []float64
 }
 
-// Creates a new vector with a backing slice filled with the contents
+// NewVecNFromData creates a new vector with a backing slice filled with the contents
 // of initial. It is NOT backed by initial, but rather a slice with cap
 // 2^p where p is Ceil(log_2(len(initial))), with the data from initial copied into
 // it.
@@ -41,7 +41,7 @@ func NewVecNFromData(initial []float64) *VecN {
 	return &VecN{vec: internal}
 }
 
-// Creates a new vector with a backing slice of
+// NewVecN creates a new vector with a backing slice of
 // 2^p where p = Ceil(log_2(n))
 func NewVecN(n int) *VecN {
 	if shouldPool {
@@ -51,7 +51,7 @@ func NewVecN(n int) *VecN {
 	}
 }
 
-// Returns the raw slice backing the VecN
+// Raw returns the raw slice backing the VecN
 //
 // This may be sent back to the memory pool at any time
 // and you aren't advised to rely on this value
@@ -59,13 +59,13 @@ func (vn VecN) Raw() []float64 {
 	return vn.vec
 }
 
-// Gets the element at index i from the vector.
-// This does not bounds check, and will panic if i is
-// out of range.
+// Get the element at index i from the vector. This does not bounds check, and
+// will panic if i is out of range.
 func (vn VecN) Get(i int) float64 {
 	return vn.vec[i]
 }
 
+// Set the element at index i to val.
 func (vn *VecN) Set(i int, val float64) {
 	vn.vec[i] = val
 }
@@ -82,11 +82,12 @@ func (vn *VecN) destroy() {
 	vn.vec = nil
 }
 
-// Resizes the underlying slice to the desired amount, reallocating or retrieving from the pool
-// if necessary. The values after a Resize cannot be expected to be related to the values before a Resize.
+// Resize the underlying slice to the desired amount, reallocating or retrieving
+// from the pool if necessary. The values after a Resize cannot be expected to
+// be related to the values before a Resize.
 //
-// If the caller is a nil pointer, this returns a value as if NewVecN(n) had been called,
-// otherwise it simply returns the caller.
+// If the caller is a nil pointer, this returns a value as if NewVecN(n) had
+// been called, otherwise it simply returns the caller.
 func (vn *VecN) Resize(n int) *VecN {
 	if vn == nil {
 		return NewVecN(n)
@@ -109,25 +110,25 @@ func (vn *VecN) Resize(n int) *VecN {
 	return vn
 }
 
-// Sets the vector's backing slice to the given
+// SetBackingSlice sets the vector's backing slice to the given
 // new one.
 func (vn *VecN) SetBackingSlice(newSlice []float64) {
 	vn.vec = newSlice
 }
 
-// Return the len of the vector's underlying slice.
+// Size returns the len of the vector's underlying slice.
 // This is not titled Len because it conflicts the package's
 // convention of calling the Norm the Len.
 func (vn *VecN) Size() int {
 	return len(vn.vec)
 }
 
-// Returns the cap of the vector's underlying slice.
+// Cap Returns the cap of the vector's underlying slice.
 func (vn *VecN) Cap() int {
 	return cap(vn.vec)
 }
 
-// Sets the vector's size to n and zeroes out the vector.
+// Zero sets the vector's size to n and zeroes out the vector.
 // If n is bigger than the vector's size, it will realloc.
 func (vn *VecN) Zero(n int) {
 	vn.Resize(n)
@@ -136,7 +137,7 @@ func (vn *VecN) Zero(n int) {
 	}
 }
 
-// Adds vn and addend, storing the result in dst.
+// Add adds vn and addend, storing the result in dst.
 // If dst does not have sufficient size it will be resized
 // Dst may be one of the other arguments. If dst is nil, it will be allocated.
 // The value returned is dst, for easier method chaining
@@ -157,7 +158,7 @@ func (vn *VecN) Add(dst *VecN, subtrahend *VecN) *VecN {
 	return dst
 }
 
-// Subtracts addend from vn, storing the result in dst.
+// Sub subtracts addend from vn, storing the result in dst.
 // If dst does not have sufficient size it will be resized
 // Dst may be one of the other arguments. If dst is nil, it will be allocated.
 // The value returned is dst, for easier method chaining
@@ -178,7 +179,7 @@ func (vn *VecN) Sub(dst *VecN, addend *VecN) *VecN {
 	return dst
 }
 
-// Takes the binary cross product of vn and other, and stores it in dst.
+// Cross takes the binary cross product of vn and other, and stores it in dst.
 // If either vn or other are not of size 3 this function will panic
 //
 // If dst is not of sufficient size, or is nil, a new slice is allocated.
@@ -205,7 +206,7 @@ func intMin(a, b int) int {
 	return b
 }
 
-// Computes the dot product of two VecNs, if
+// Dot computes the dot product of two VecNs, if
 // the two vectors are not of the same length -- this
 // will return NaN.
 func (vn *VecN) Dot(other *VecN) float64 {
@@ -221,7 +222,7 @@ func (vn *VecN) Dot(other *VecN) float64 {
 	return result
 }
 
-// Computes the vector length (also called the Norm) of the
+// Len computes the vector length (also called the Norm) of the
 // vector. Equivalent to math.Sqrt(vn.Dot(vn)) with the appropriate
 // type conversions.
 //
@@ -237,7 +238,7 @@ func (vn *VecN) Len() float64 {
 	return float64(math.Sqrt(float64(vn.Dot(vn))))
 }
 
-// Normalizes the vector and stores the result in dst, which
+// Normalize the vector and stores the result in dst, which
 // will be returned. Dst will be appropraitely resized to the
 // size of vn.
 //
@@ -252,9 +253,8 @@ func (vn *VecN) Normalize(dst *VecN) *VecN {
 	return vn.Mul(dst, 1/vn.Len())
 }
 
-// Multiplied the vector by some scalar value and stores the result in dst, which
-// will be returned. Dst will be appropraitely resized to the
-// size of vn.
+// Mul multiplies the vector by some scalar value and stores the result in dst,
+// which will be returned. Dst will be appropriately resized to the size of vn.
 //
 // The destination can be vn itself and nothing will go wrong.
 func (vn *VecN) Mul(dst *VecN, c float64) *VecN {
@@ -270,7 +270,7 @@ func (vn *VecN) Mul(dst *VecN, c float64) *VecN {
 	return dst
 }
 
-// Performs the vector outer product between vn and v2.
+// OuterProd performs the vector outer product between vn and v2.
 // The outer product is like a "reverse" dot product. Where the dot product
 // aligns both vectors with the "sized" part facing "inward" (Vec3*Vec3=Mat1x3*Mat3x1=Mat1x1=Scalar).
 // The outer product multiplied them with it facing "outward"
@@ -294,6 +294,8 @@ func (vn *VecN) OuterProd(dst *MatMxN, v2 *VecN) *MatMxN {
 	return dst
 }
 
+// ApproxEqual returns whether the two vectors are approximately equal (See
+// FloatEqual).
 func (vn *VecN) ApproxEqual(vn2 *VecN) bool {
 	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
 		return false
@@ -308,6 +310,8 @@ func (vn *VecN) ApproxEqual(vn2 *VecN) bool {
 	return true
 }
 
+// ApproxEqualThreshold returns whether the two vectors are approximately equal
+// to within the given threshold given by "epsilon" (See ApproxEqualThreshold).
 func (vn *VecN) ApproxEqualThreshold(vn2 *VecN, epsilon float64) bool {
 	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
 		return false
@@ -322,6 +326,8 @@ func (vn *VecN) ApproxEqualThreshold(vn2 *VecN, epsilon float64) bool {
 	return true
 }
 
+// ApproxEqualFunc returns whether the two vectors are approximately equal,
+// given a function which compares two scalar elements.
 func (vn *VecN) ApproxEqualFunc(vn2 *VecN, comp func(float64, float64) bool) bool {
 	if vn == nil || vn2 == nil || len(vn.vec) != len(vn2.vec) {
 		return false
@@ -336,16 +342,19 @@ func (vn *VecN) ApproxEqualFunc(vn2 *VecN, comp func(float64, float64) bool) boo
 	return true
 }
 
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
 func (vn *VecN) Vec2() Vec2 {
 	raw := vn.Raw()
 	return Vec2{raw[0], raw[1]}
 }
 
+// Vec3 constructs a 3-dimensional vector by discarding coordinates.
 func (vn *VecN) Vec3() Vec3 {
 	raw := vn.Raw()
 	return Vec3{raw[0], raw[1], raw[2]}
 }
 
+// Vec4 constructs a 4-dimensional vector by discarding coordinates.
 func (vn *VecN) Vec4() Vec4 {
 	raw := vn.Raw()
 	return Vec4{raw[0], raw[1], raw[2], raw[3]}

--- a/mgl64/vector.go
+++ b/mgl64/vector.go
@@ -19,26 +19,32 @@ type Vec2 f64.Vec2
 type Vec3 f64.Vec3
 type Vec4 f64.Vec4
 
+// Vec3 constructs a 3-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec3(z float64) Vec3 {
 	return Vec3{v[0], v[1], z}
 }
 
+// Vec4 constructs a 4-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec4(z, w float64) Vec4 {
 	return Vec4{v[0], v[1], z, w}
 }
 
-func (v Vec3) Vec2() Vec2 {
-	return Vec2{v[0], v[1]}
-}
-
+// Vec4 constructs a 4-dimensional vector by appending the given coordinates.
 func (v Vec3) Vec4(w float64) Vec4 {
 	return Vec4{v[0], v[1], v[2], w}
 }
 
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
+func (v Vec3) Vec2() Vec2 {
+	return Vec2{v[0], v[1]}
+}
+
+// Vec2 constructs a 2-dimensional vector by discarding coordinates.
 func (v Vec4) Vec2() Vec2 {
 	return Vec2{v[0], v[1]}
 }
 
+// Vec3 constructs a 3-dimensional vector by discarding coordinates.
 func (v Vec4) Vec3() Vec3 {
 	return Vec3{v[0], v[1], v[2]}
 }
@@ -58,25 +64,28 @@ func (v Vec4) Elem() (x, y, z, w float64) {
 	return v[0], v[1], v[2], v[3]
 }
 
-// The vector cross product is an operation only defined on 3D vectors. It is equivalent to
-// Vec3{v1[1]*v2[2]-v1[2]*v2[1], v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}.
-// Another interpretation is that it's the vector whose magnitude is |v1||v2|sin(theta)
-// where theta is the angle between v1 and v2.
+// Cross is the vector cross product. This operation is only defined on 3D
+// vectors. It is equivalent to Vec3{v1[1]*v2[2]-v1[2]*v2[1],
+// v1[2]*v2[0]-v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}. Another interpretation
+// is that it's the vector whose magnitude is |v1||v2|sin(theta) where theta is
+// the angle between v1 and v2.
 //
-// The cross product is most often used for finding surface normals. The cross product of vectors
-// will generate a vector that is perpendicular to the plane they form.
+// The cross product is most often used for finding surface normals. The cross
+// product of vectors will generate a vector that is perpendicular to the plane
+// they form.
 //
 // Technically, a generalized cross product exists as an "(N-1)ary" operation
-// (that is, the 4D cross product requires 3 4D vectors). But the binary
-// 3D (and 7D) cross product is the most important. It can be considered
-// the area of a parallelogram with sides v1 and v2.
+// (that is, the 4D cross product requires 3 4D vectors). But the binary 3D (and
+// 7D) cross product is the most important. It can be considered the area of a
+// parallelogram with sides v1 and v2.
 //
-// Like the dot product, the cross product is roughly a measure of directionality.
-// Two normalized perpendicular vectors will return a vector with a magnitude of
-// 1.0 or -1.0 and two parallel vectors will return a vector with magnitude 0.0.
-// The cross product is "anticommutative" meaning v1.Cross(v2) = -v2.Cross(v1),
-// this property can be useful to know when finding normals,
-// as taking the wrong cross product can lead to the opposite normal of the one you want.
+// Like the dot product, the cross product is roughly a measure of
+// directionality. Two normalized perpendicular vectors will return a vector
+// with a magnitude of 1.0 or -1.0 and two parallel vectors will return a vector
+// with magnitude 0.0. The cross product is "anticommutative" meaning
+// v1.Cross(v2) = -v2.Cross(v1), this property can be useful to know when
+// finding normals, as taking the wrong cross product can lead to the opposite
+// normal of the one you want.
 func (v1 Vec3) Cross(v2 Vec3) Vec3 {
 	return Vec3{v1[1]*v2[2] - v1[2]*v2[1], v1[2]*v2[0] - v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}
 }
@@ -140,8 +149,8 @@ func (v1 Vec2) Normalize() Vec2 {
 	return Vec2{v1[0] * l, v1[1] * l}
 }
 
-// ApproxEqual takes in a vector and does an element-wise
-// approximate float comparison as if FloatEqual had been used
+// ApproxEqual takes in a vector and does an element-wise approximate float
+// comparison as if FloatEqual had been used
 func (v1 Vec2) ApproxEqual(v2 Vec2) bool {
 	for i := range v1 {
 		if !FloatEqual(v1[i], v2[i]) {
@@ -151,8 +160,8 @@ func (v1 Vec2) ApproxEqual(v2 Vec2) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
-// element-wise comparison of the vector to another.
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses
+// it to do an element-wise comparison of the vector to another.
 func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float64) bool {
 	for i := range v1 {
 		if !FloatEqualThreshold(v1[i], v2[i], threshold) {
@@ -162,7 +171,7 @@ func (v1 Vec2) ApproxEqualThreshold(v2 Vec2, threshold float64) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec2) ApproxFuncEqual(v2 Vec2, eq func(float64, float64) bool) bool {
 	for i := range v1 {
@@ -173,7 +182,7 @@ func (v1 Vec2) ApproxFuncEqual(v2 Vec2, eq func(float64, float64) bool) bool {
 	return true
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// X is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -181,7 +190,7 @@ func (v Vec2) X() float64 {
 	return v[0]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Y is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -189,7 +198,7 @@ func (v Vec2) Y() float64 {
 	return v[1]
 }
 
-// Does the vector outer product
+// OuterProd2 does the vector outer product
 // of two vectors. The outer product produces an
 // 2x2 matrix. E.G. a Vec2 * Vec2 = Mat2.
 //
@@ -204,7 +213,7 @@ func (v1 Vec2) OuterProd2(v2 Vec2) Mat2 {
 	return Mat2{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 does the vector outer product
 // of two vectors. The outer product produces an
 // 2x3 matrix. E.G. a Vec2 * Vec3 = Mat2x3.
 //
@@ -219,7 +228,7 @@ func (v1 Vec2) OuterProd3(v2 Vec3) Mat2x3 {
 	return Mat2x3{v1[0] * v2[0], v1[1] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[0] * v2[2], v1[1] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 does the vector outer product
 // of two vectors. The outer product produces an
 // 2x4 matrix. E.G. a Vec2 * Vec4 = Mat2x4.
 //
@@ -293,8 +302,8 @@ func (v1 Vec3) Normalize() Vec3 {
 	return Vec3{v1[0] * l, v1[1] * l, v1[2] * l}
 }
 
-// ApproxEqual takes in a vector and does an element-wise
-// approximate float comparison as if FloatEqual had been used
+// ApproxEqual takes in a vector and does an element-wise approximate float
+// comparison as if FloatEqual had been used
 func (v1 Vec3) ApproxEqual(v2 Vec3) bool {
 	for i := range v1 {
 		if !FloatEqual(v1[i], v2[i]) {
@@ -304,8 +313,8 @@ func (v1 Vec3) ApproxEqual(v2 Vec3) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
-// element-wise comparison of the vector to another.
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses
+// it to do an element-wise comparison of the vector to another.
 func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float64) bool {
 	for i := range v1 {
 		if !FloatEqualThreshold(v1[i], v2[i], threshold) {
@@ -315,7 +324,7 @@ func (v1 Vec3) ApproxEqualThreshold(v2 Vec3, threshold float64) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec3) ApproxFuncEqual(v2 Vec3, eq func(float64, float64) bool) bool {
 	for i := range v1 {
@@ -326,7 +335,7 @@ func (v1 Vec3) ApproxFuncEqual(v2 Vec3, eq func(float64, float64) bool) bool {
 	return true
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// X is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -334,7 +343,7 @@ func (v Vec3) X() float64 {
 	return v[0]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Y is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -342,7 +351,7 @@ func (v Vec3) Y() float64 {
 	return v[1]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Z is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -350,7 +359,7 @@ func (v Vec3) Z() float64 {
 	return v[2]
 }
 
-// Does the vector outer product
+// OuterProd2 does the vector outer product
 // of two vectors. The outer product produces an
 // 3x2 matrix. E.G. a Vec3 * Vec2 = Mat3x2.
 //
@@ -365,7 +374,7 @@ func (v1 Vec3) OuterProd2(v2 Vec2) Mat3x2 {
 	return Mat3x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 does the vector outer product
 // of two vectors. The outer product produces an
 // 3x3 matrix. E.G. a Vec3 * Vec3 = Mat3.
 //
@@ -380,7 +389,7 @@ func (v1 Vec3) OuterProd3(v2 Vec3) Mat3 {
 	return Mat3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 does the vector outer product
 // of two vectors. The outer product produces an
 // 3x4 matrix. E.G. a Vec3 * Vec4 = Mat3x4.
 //
@@ -454,8 +463,8 @@ func (v1 Vec4) Normalize() Vec4 {
 	return Vec4{v1[0] * l, v1[1] * l, v1[2] * l, v1[3] * l}
 }
 
-// ApproxEqual takes in a vector and does an element-wise
-// approximate float comparison as if FloatEqual had been used
+// ApproxEqual takes in a vector and does an element-wise approximate float
+// comparison as if FloatEqual had been used
 func (v1 Vec4) ApproxEqual(v2 Vec4) bool {
 	for i := range v1 {
 		if !FloatEqual(v1[i], v2[i]) {
@@ -465,8 +474,8 @@ func (v1 Vec4) ApproxEqual(v2 Vec4) bool {
 	return true
 }
 
-// ApproxThresholdEq takes in a threshold for comparing two floats, and uses it to do an
-// element-wise comparison of the vector to another.
+// ApproxEqualThreshold takes in a threshold for comparing two floats, and uses
+// it to do an element-wise comparison of the vector to another.
 func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float64) bool {
 	for i := range v1 {
 		if !FloatEqualThreshold(v1[i], v2[i], threshold) {
@@ -476,7 +485,7 @@ func (v1 Vec4) ApproxEqualThreshold(v2 Vec4, threshold float64) bool {
 	return true
 }
 
-// ApproxFuncEq takes in a func that compares two floats, and uses it to do an element-wise
+// ApproxFuncEqual takes in a func that compares two floats, and uses it to do an element-wise
 // comparison of the vector to another. This is intended to be used with FloatEqualFunc
 func (v1 Vec4) ApproxFuncEqual(v2 Vec4, eq func(float64, float64) bool) bool {
 	for i := range v1 {
@@ -487,7 +496,7 @@ func (v1 Vec4) ApproxFuncEqual(v2 Vec4, eq func(float64, float64) bool) bool {
 	return true
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// X is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -495,7 +504,7 @@ func (v Vec4) X() float64 {
 	return v[0]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Y is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -503,7 +512,7 @@ func (v Vec4) Y() float64 {
 	return v[1]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// Z is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -511,7 +520,7 @@ func (v Vec4) Z() float64 {
 	return v[2]
 }
 
-// This is an element access func, it is equivalent to v[n] where
+// W is an element access func, it is equivalent to v[n] where
 // n is some valid index. The mappings are XYZW (X=0, Y=1 etc). Benchmarks
 // show that this is more or less as fast as direct acces, probably due to
 // inlining, so use v[0] or v.X() depending on personal preference.
@@ -519,7 +528,7 @@ func (v Vec4) W() float64 {
 	return v[3]
 }
 
-// Does the vector outer product
+// OuterProd2 does the vector outer product
 // of two vectors. The outer product produces an
 // 4x2 matrix. E.G. a Vec4 * Vec2 = Mat4x2.
 //
@@ -534,7 +543,7 @@ func (v1 Vec4) OuterProd2(v2 Vec2) Mat4x2 {
 	return Mat4x2{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1]}
 }
 
-// Does the vector outer product
+// OuterProd3 does the vector outer product
 // of two vectors. The outer product produces an
 // 4x3 matrix. E.G. a Vec4 * Vec3 = Mat4x3.
 //
@@ -549,7 +558,7 @@ func (v1 Vec4) OuterProd3(v2 Vec3) Mat4x3 {
 	return Mat4x3{v1[0] * v2[0], v1[1] * v2[0], v1[2] * v2[0], v1[3] * v2[0], v1[0] * v2[1], v1[1] * v2[1], v1[2] * v2[1], v1[3] * v2[1], v1[0] * v2[2], v1[1] * v2[2], v1[2] * v2[2], v1[3] * v2[2]}
 }
 
-// Does the vector outer product
+// OuterProd4 does the vector outer product
 // of two vectors. The outer product produces an
 // 4x4 matrix. E.G. a Vec4 * Vec4 = Mat4.
 //


### PR DESCRIPTION
Further to pull request in #75.

Turned out to be a surprisingly large amount of low value work :(. It's done now I suppose.

This was done on a best effort basis. I've reviewed the patch and don't think there are any non-comment/whitespace changes present. I have verified this by grepping for `^\+[^/]` which looks for diff lines not starting with /.

There was one minor thing where I reordered a small function to make it easier to edit the comments in bulk.