### PR TITLE
Travis: use latest patch versions, re-add go vet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 sudo: false
 language: go
 go:
-  - 1.11.8
-  - 1.12.3
+  - 1.12.x
+  - 1.11.x
   - tip
 matrix:
   allow_failures:
@@ -13,4 +13,5 @@ install:
 script:
   - go get -t -v ./...
   - diff -u <(echo -n) <(gofmt -d -s .)
+  - go vet ./...
   - go test -v -race ./...


### PR DESCRIPTION
Specifying latest patch versions means less `.travis.yml` file maintenance for us.

Re-order the versions so that the current version (1.12) is listed first, and the older version (1.11) is listed second.

Re-add `go vet` since it runs additional valuable checks on top of the ones that `go test` runs.

Updates #76