### PR TITLE
Add Vec4.Quat() method to reinterpret a vec4 as a quaternion

### DIFF
--- a/mgl32/vector.go
+++ b/mgl32/vector.go
@@ -87,6 +87,12 @@ func (v1 Vec3) Cross(v2 Vec3) Vec3 {
 	return Vec3{v1[1]*v2[2] - v1[2]*v2[1], v1[2]*v2[0] - v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}
 }
 
+// Quat reinterprets this vector as a quaternion, with the individual elements
+// staying the same.
+func (v Vec4) Quat() Quat {
+	return Quat{v[3], Vec3{v[0], v[1], v[2]}}
+}
+
 // Add performs element-wise addition between two vectors. It is equivalent to iterating
 // over every element of v1 and adding the corresponding element of v2 to it.
 func (v1 Vec2) Add(v2 Vec2) Vec2 {

--- a/mgl32/vector.tmpl
+++ b/mgl32/vector.tmpl
@@ -87,6 +87,12 @@ func (v1 Vec3) Cross(v2 Vec3) Vec3 {
 	return Vec3{v1[1]*v2[2] - v1[2]*v2[1], v1[2]*v2[0] - v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}
 }
 
+// Quat reinterprets this vector as a quaternion, with the individual elements
+// staying the same.
+func (v Vec4) Quat() Quat {
+	return Quat{v[3], Vec3{v[0], v[1], v[2]}}
+}
+
 
 <</* Common functions for all vectors */>>
 <<range $m := enum 2 3 4>>

--- a/mgl64/vector.go
+++ b/mgl64/vector.go
@@ -90,6 +90,12 @@ func (v1 Vec3) Cross(v2 Vec3) Vec3 {
 	return Vec3{v1[1]*v2[2] - v1[2]*v2[1], v1[2]*v2[0] - v1[0]*v2[2], v1[0]*v2[1] - v1[1]*v2[0]}
 }
 
+// Quat reinterprets this vector as a quaternion, with the individual elements
+// staying the same.
+func (v Vec4) Quat() Quat {
+	return Quat{v[3], Vec3{v[0], v[1], v[2]}}
+}
+
 // Add performs element-wise addition between two vectors. It is equivalent to iterating
 // over every element of v1 and adding the corresponding element of v2 to it.
 func (v1 Vec2) Add(v2 Vec2) Vec2 {


### PR DESCRIPTION
This can sometimes be useful, for example, if the result of a matrix multiplication is a quaternion but you only have a Vec4.

---

Note: I needed to do this while working on a Madgwick filter that is based on MathGL. It is mostly based on quaternions but there is a matrix multiplication that results in a `Vec4` while I really needed a `Quat`. The conversion is trivial, but it would be useful to have it directly in MathGL.