### PR TITLE
Use Sincos instead of Sin, Cos

### DIFF
--- a/mgl32/codegen.go
+++ b/mgl32/codegen.go
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
+//go:build ignore
 // +build ignore
 
 // codegen generates go code from templates. Intended to be

--- a/mgl32/matmn.go
+++ b/mgl32/matmn.go
@@ -40,8 +40,8 @@ func NewMatrix(m, n int) (mat *MatMxN) {
 //
 // For instance, to create a 3x3 MatMN from a Mat3
 //
-//    m1 := mgl32.Rotate3DX(3.14159)
-//    mat := mgl32.NewBackedMatrix(m1[:],3,3)
+//	m1 := mgl32.Rotate3DX(3.14159)
+//	mat := mgl32.NewBackedMatrix(m1[:],3,3)
 //
 // will create an MN matrix matching the data in the original rotation matrix.
 // This matrix is NOT backed by the initial slice; it's a copy of the data

--- a/mgl32/matrix.go
+++ b/mgl32/matrix.go
@@ -203,9 +203,9 @@ func (m1 Mat2) Mul2x4(m2 Mat2x4) Mat2x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat2) Transpose() Mat2 {
 	return Mat2{m1[0], m1[2], m1[1], m1[3]}
 }
@@ -458,9 +458,9 @@ func (m1 Mat2x3) Mul3x4(m2 Mat3x4) Mat2x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat2x3) Transpose() Mat3x2 {
 	return Mat3x2{m1[0], m1[2], m1[4], m1[1], m1[3], m1[5]}
 }
@@ -676,9 +676,9 @@ func (m1 Mat2x4) Mul4(m2 Mat4) Mat2x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat2x4) Transpose() Mat4x2 {
 	return Mat4x2{m1[0], m1[2], m1[4], m1[6], m1[1], m1[3], m1[5], m1[7]}
 }
@@ -904,9 +904,9 @@ func (m1 Mat3x2) Mul2x4(m2 Mat2x4) Mat3x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat3x2) Transpose() Mat2x3 {
 	return Mat2x3{m1[0], m1[3], m1[1], m1[4], m1[2], m1[5]}
 }
@@ -1156,9 +1156,9 @@ func (m1 Mat3) Mul3x4(m2 Mat3x4) Mat3x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat3) Transpose() Mat3 {
 	return Mat3{m1[0], m1[3], m1[6], m1[1], m1[4], m1[7], m1[2], m1[5], m1[8]}
 }
@@ -1431,9 +1431,9 @@ func (m1 Mat3x4) Mul4(m2 Mat4) Mat3x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat3x4) Transpose() Mat4x3 {
 	return Mat4x3{m1[0], m1[3], m1[6], m1[9], m1[1], m1[4], m1[7], m1[10], m1[2], m1[5], m1[8], m1[11]}
 }
@@ -1669,9 +1669,9 @@ func (m1 Mat4x2) Mul2x4(m2 Mat2x4) Mat4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat4x2) Transpose() Mat2x4 {
 	return Mat2x4{m1[0], m1[4], m1[1], m1[5], m1[2], m1[6], m1[3], m1[7]}
 }
@@ -1907,9 +1907,9 @@ func (m1 Mat4x3) Mul3x4(m2 Mat3x4) Mat4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat4x3) Transpose() Mat3x4 {
 	return Mat3x4{m1[0], m1[4], m1[8], m1[1], m1[5], m1[9], m1[2], m1[6], m1[10], m1[3], m1[7], m1[11]}
 }
@@ -2169,9 +2169,9 @@ func (m1 Mat4) Mul4(m2 Mat4) Mat4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat4) Transpose() Mat4 {
 	return Mat4{m1[0], m1[4], m1[8], m1[12], m1[1], m1[5], m1[9], m1[13], m1[2], m1[6], m1[10], m1[14], m1[3], m1[7], m1[11], m1[15]}
 }

--- a/mgl32/quat.go
+++ b/mgl32/quat.go
@@ -56,7 +56,8 @@ func QuatIdent() Quat {
 func QuatRotate(angle float32, axis Vec3) Quat {
 	// angle = (float32(math.Pi) * angle) / 180.0
 
-	c, s := float32(math.Cos(float64(angle/2))), float32(math.Sin(float64(angle/2)))
+	sn, cs := math.Sincos(float64(angle / 2))
+	s, c := float32(sn), float32(cs)
 
 	return Quat{c, axis.Mul(s)}
 }
@@ -233,7 +234,8 @@ func QuatSlerp(q1, q2 Quat, amount float32) Quat {
 	dot = Clamp(dot, -1, 1)
 
 	theta := float32(math.Acos(float64(dot))) * amount
-	c, s := float32(math.Cos(float64(theta))), float32(math.Sin(float64(theta)))
+	sn, cs := math.Sincos(float64(theta))
+	s, c := float32(sn), float32(cs)
 	rel := q2.Sub(q1.Scale(dot)).Normalize()
 
 	return q1.Scale(c).Add(rel.Scale(s))

--- a/mgl32/transform.go
+++ b/mgl32/transform.go
@@ -18,47 +18,47 @@ func Rotate2D(angle float32) Mat2 {
 // Rotate3DX returns a 3x3 (non-homogeneous) Matrix that rotates by angle about the X-axis
 //
 // Where c is cos(angle) and s is sin(angle)
-//    [1 0 0]
-//    [0 c -s]
-//    [0 s c ]
+//
+//	[1 0 0]
+//	[0 c -s]
+//	[0 s c ]
 func Rotate3DX(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
-
 	return Mat3{1, 0, 0, 0, cos, sin, 0, -sin, cos}
 }
 
 // Rotate3DY returns a 3x3 (non-homogeneous) Matrix that rotates by angle about the Y-axis
 //
 // Where c is cos(angle) and s is sin(angle)
-//    [c 0 s]
-//    [0 1 0]
-//    [s 0 c ]
+//
+//	[c 0 s]
+//	[0 1 0]
+//	[s 0 c ]
 func Rotate3DY(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
-
 	return Mat3{cos, 0, -sin, 0, 1, 0, sin, 0, cos}
 }
 
 // Rotate3DZ returns a 3x3 (non-homogeneous) Matrix that rotates by angle about the Z-axis
 //
 // Where c is cos(angle) and s is sin(angle)
-//    [c -s 0]
-//    [s c 0]
-//    [0 0 1 ]
+//
+//	[c -s 0]
+//	[s c 0]
+//	[0 0 1 ]
 func Rotate3DZ(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
-
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
 // Translate2D returns a homogeneous (3x3 for 2D-space) Translation matrix that moves a point by Tx units in the x-direction and Ty units in the y-direction
 //
-//    [[1, 0, Tx]]
-//    [[0, 1, Ty]]
-//    [[0, 0, 1 ]]
+//	[[1, 0, Tx]]
+//	[[0, 1, Ty]]
+//	[[0, 0, 1 ]]
 func Translate2D(Tx, Ty float32) Mat3 {
 	return Mat3{1, 0, 0, 0, 1, 0, float32(Tx), float32(Ty), 1}
 }
@@ -66,10 +66,10 @@ func Translate2D(Tx, Ty float32) Mat3 {
 // Translate3D returns a homogeneous (4x4 for 3D-space) Translation matrix that moves a point by Tx units in the x-direction, Ty units in the y-direction,
 // and Tz units in the z-direction
 //
-//    [[1, 0, 0, Tx]]
-//    [[0, 1, 0, Ty]]
-//    [[0, 0, 1, Tz]]
-//    [[0, 0, 0, 1 ]]
+//	[[1, 0, 0, Tx]]
+//	[[0, 1, 0, Ty]]
+//	[[0, 0, 1, Tz]]
+//	[[0, 0, 0, 1 ]]
 func Translate3D(Tx, Ty, Tz float32) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, float32(Tx), float32(Ty), float32(Tz), 1}
 }
@@ -152,10 +152,10 @@ func ShearZ3D(shearX, shearY float32) Mat4 {
 //
 // Where c is cos(angle) and s is sin(angle), and x, y, and z are the first, second, and third elements of the axis vector (respectively):
 //
-//    [[ x^2(1-c)+c, xy(1-c)-zs, xz(1-c)+ys, 0 ]]
-//    [[ xy(1-c)+zs, y^2(1-c)+c, yz(1-c)-xs, 0 ]]
-//    [[ xz(1-c)-ys, yz(1-c)+xs, z^2(1-c)+c, 0 ]]
-//    [[ 0         , 0         , 0         , 1 ]]
+//	[[ x^2(1-c)+c, xy(1-c)-zs, xz(1-c)+ys, 0 ]]
+//	[[ xy(1-c)+zs, y^2(1-c)+c, yz(1-c)-xs, 0 ]]
+//	[[ xz(1-c)-ys, yz(1-c)+xs, z^2(1-c)+c, 0 ]]
+//	[[ 0         , 0         , 0         , 1 ]]
 func HomogRotate3D(angle float32, axis Vec3) Mat4 {
 	x, y, z := axis[0], axis[1], axis[2]
 	s, c := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
@@ -194,9 +194,10 @@ func Mat4Normal(m Mat4) Mat3 {
 // This is similar to saying you're transforming and projecting a point.
 //
 // This is effectively equivalent to the GLSL code
-//     vec4 r = (m * vec4(v,1.));
-//     r = r/r.w;
-//     vec3 newV = r.xyz;
+//
+//	vec4 r = (m * vec4(v,1.));
+//	r = r/r.w;
+//	vec3 newV = r.xyz;
 func TransformCoordinate(v Vec3, m Mat4) Vec3 {
 	t := v.Vec4(1)
 	t = m.Mul4x1(t)
@@ -213,8 +214,9 @@ func TransformCoordinate(v Vec3, m Mat4) Vec3 {
 // but translating a direction or normal is meaningless.
 //
 // This is effectively equivalent to the GLSL code
-//    vec4 r = (m * vec4(v,0.));
-//    vec3 newV = r.xyz
+//
+//	vec4 r = (m * vec4(v,0.));
+//	vec3 newV = r.xyz
 func TransformNormal(v Vec3, m Mat4) Vec3 {
 	t := v.Vec4(0)
 	t = m.Mul4x1(t)

--- a/mgl32/transform.go
+++ b/mgl32/transform.go
@@ -11,7 +11,8 @@ import "math"
 // see HomogRotate2D
 func Rotate2D(angle float32) Mat2 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 	return Mat2{cos, sin, -sin, cos}
 }
 
@@ -24,7 +25,8 @@ func Rotate2D(angle float32) Mat2 {
 //	[0 s c ]
 func Rotate3DX(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 	return Mat3{1, 0, 0, 0, cos, sin, 0, -sin, cos}
 }
 
@@ -37,7 +39,8 @@ func Rotate3DX(angle float32) Mat3 {
 //	[s 0 c ]
 func Rotate3DY(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 	return Mat3{cos, 0, -sin, 0, 1, 0, sin, 0, cos}
 }
 
@@ -50,7 +53,8 @@ func Rotate3DY(angle float32) Mat3 {
 //	[0 0 1 ]
 func Rotate3DZ(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
@@ -77,14 +81,16 @@ func Translate3D(Tx, Ty, Tz float32) Mat4 {
 // HomogRotate2D is the same as Rotate2D, except homogeneous (3x3 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate2D(angle float32) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
 // HomogRotate3DX is the same as Rotate3DX, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DX(angle float32) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 
 	return Mat4{1, 0, 0, 0, 0, cos, sin, 0, 0, -sin, cos, 0, 0, 0, 0, 1}
 }
@@ -92,14 +98,16 @@ func HomogRotate3DX(angle float32) Mat4 {
 // HomogRotate3DY is the same as Rotate3DY, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DY(angle float32) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 	return Mat4{cos, 0, -sin, 0, 0, 1, 0, 0, sin, 0, cos, 0, 0, 0, 0, 1}
 }
 
 // HomogRotate3DZ is the same as Rotate3DZ, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DZ(angle float32) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float32(sn), float32(cs)
 	return Mat4{cos, sin, 0, 0, -sin, cos, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}
 }
 
@@ -158,7 +166,8 @@ func ShearZ3D(shearX, shearY float32) Mat4 {
 //	[[ 0         , 0         , 0         , 1 ]]
 func HomogRotate3D(angle float32, axis Vec3) Mat4 {
 	x, y, z := axis[0], axis[1], axis[2]
-	s, c := float32(math.Sin(float64(angle))), float32(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	s, c := float32(sn), float32(cs)
 	k := 1 - c
 
 	return Mat4{x*x*k + c, x*y*k + z*s, x*z*k - y*s, 0, x*y*k - z*s, y*y*k + c, y*z*k + x*s, 0, x*z*k + y*s, y*z*k - x*s, z*z*k + c, 0, 0, 0, 0, 1}

--- a/mgl64/matmn.go
+++ b/mgl64/matmn.go
@@ -42,8 +42,8 @@ func NewMatrix(m, n int) (mat *MatMxN) {
 //
 // For instance, to create a 3x3 MatMN from a Mat3
 //
-//    m1 := mgl32.Rotate3DX(3.14159)
-//    mat := mgl32.NewBackedMatrix(m1[:],3,3)
+//	m1 := mgl32.Rotate3DX(3.14159)
+//	mat := mgl32.NewBackedMatrix(m1[:],3,3)
 //
 // will create an MN matrix matching the data in the original rotation matrix.
 // This matrix is NOT backed by the initial slice; it's a copy of the data

--- a/mgl64/matrix.go
+++ b/mgl64/matrix.go
@@ -206,9 +206,9 @@ func (m1 Mat2) Mul2x4(m2 Mat2x4) Mat2x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat2) Transpose() Mat2 {
 	return Mat2{m1[0], m1[2], m1[1], m1[3]}
 }
@@ -461,9 +461,9 @@ func (m1 Mat2x3) Mul3x4(m2 Mat3x4) Mat2x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat2x3) Transpose() Mat3x2 {
 	return Mat3x2{m1[0], m1[2], m1[4], m1[1], m1[3], m1[5]}
 }
@@ -679,9 +679,9 @@ func (m1 Mat2x4) Mul4(m2 Mat4) Mat2x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat2x4) Transpose() Mat4x2 {
 	return Mat4x2{m1[0], m1[2], m1[4], m1[6], m1[1], m1[3], m1[5], m1[7]}
 }
@@ -907,9 +907,9 @@ func (m1 Mat3x2) Mul2x4(m2 Mat2x4) Mat3x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat3x2) Transpose() Mat2x3 {
 	return Mat2x3{m1[0], m1[3], m1[1], m1[4], m1[2], m1[5]}
 }
@@ -1159,9 +1159,9 @@ func (m1 Mat3) Mul3x4(m2 Mat3x4) Mat3x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat3) Transpose() Mat3 {
 	return Mat3{m1[0], m1[3], m1[6], m1[1], m1[4], m1[7], m1[2], m1[5], m1[8]}
 }
@@ -1434,9 +1434,9 @@ func (m1 Mat3x4) Mul4(m2 Mat4) Mat3x4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat3x4) Transpose() Mat4x3 {
 	return Mat4x3{m1[0], m1[3], m1[6], m1[9], m1[1], m1[4], m1[7], m1[10], m1[2], m1[5], m1[8], m1[11]}
 }
@@ -1672,9 +1672,9 @@ func (m1 Mat4x2) Mul2x4(m2 Mat2x4) Mat4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat4x2) Transpose() Mat2x4 {
 	return Mat2x4{m1[0], m1[4], m1[1], m1[5], m1[2], m1[6], m1[3], m1[7]}
 }
@@ -1910,9 +1910,9 @@ func (m1 Mat4x3) Mul3x4(m2 Mat3x4) Mat4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat4x3) Transpose() Mat3x4 {
 	return Mat3x4{m1[0], m1[4], m1[8], m1[1], m1[5], m1[9], m1[2], m1[6], m1[10], m1[3], m1[7], m1[11]}
 }
@@ -2172,9 +2172,9 @@ func (m1 Mat4) Mul4(m2 Mat4) Mat4 {
 // the transpose is an NxM matrix with the rows swapped with the columns. For instance
 // the transpose of the Mat3x2 is a Mat2x3 like so:
 //
-//    [[a b]]    [[a c e]]
-//    [[c d]] =  [[b d f]]
-//    [[e f]]
+//	[[a b]]    [[a c e]]
+//	[[c d]] =  [[b d f]]
+//	[[e f]]
 func (m1 Mat4) Transpose() Mat4 {
 	return Mat4{m1[0], m1[4], m1[8], m1[12], m1[1], m1[5], m1[9], m1[13], m1[2], m1[6], m1[10], m1[14], m1[3], m1[7], m1[11], m1[15]}
 }

--- a/mgl64/quat.go
+++ b/mgl64/quat.go
@@ -58,7 +58,8 @@ func QuatIdent() Quat {
 func QuatRotate(angle float64, axis Vec3) Quat {
 	// angle = (float32(math.Pi) * angle) / 180.0
 
-	c, s := float64(math.Cos(float64(angle/2))), float64(math.Sin(float64(angle/2)))
+	sn, cs := math.Sincos(float64(angle / 2))
+	s, c := float64(sn), float64(cs)
 
 	return Quat{c, axis.Mul(s)}
 }
@@ -235,7 +236,8 @@ func QuatSlerp(q1, q2 Quat, amount float64) Quat {
 	dot = Clamp(dot, -1, 1)
 
 	theta := float64(math.Acos(float64(dot))) * amount
-	c, s := float64(math.Cos(float64(theta))), float64(math.Sin(float64(theta)))
+	sn, cs := math.Sincos(float64(theta))
+	s, c := float64(sn), float64(cs)
 	rel := q2.Sub(q1.Scale(dot)).Normalize()
 
 	return q1.Scale(c).Add(rel.Scale(s))

--- a/mgl64/transform.go
+++ b/mgl64/transform.go
@@ -20,47 +20,47 @@ func Rotate2D(angle float64) Mat2 {
 // Rotate3DX returns a 3x3 (non-homogeneous) Matrix that rotates by angle about the X-axis
 //
 // Where c is cos(angle) and s is sin(angle)
-//    [1 0 0]
-//    [0 c -s]
-//    [0 s c ]
+//
+//	[1 0 0]
+//	[0 c -s]
+//	[0 s c ]
 func Rotate3DX(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
-
 	return Mat3{1, 0, 0, 0, cos, sin, 0, -sin, cos}
 }
 
 // Rotate3DY returns a 3x3 (non-homogeneous) Matrix that rotates by angle about the Y-axis
 //
 // Where c is cos(angle) and s is sin(angle)
-//    [c 0 s]
-//    [0 1 0]
-//    [s 0 c ]
+//
+//	[c 0 s]
+//	[0 1 0]
+//	[s 0 c ]
 func Rotate3DY(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
-
 	return Mat3{cos, 0, -sin, 0, 1, 0, sin, 0, cos}
 }
 
 // Rotate3DZ returns a 3x3 (non-homogeneous) Matrix that rotates by angle about the Z-axis
 //
 // Where c is cos(angle) and s is sin(angle)
-//    [c -s 0]
-//    [s c 0]
-//    [0 0 1 ]
+//
+//	[c -s 0]
+//	[s c 0]
+//	[0 0 1 ]
 func Rotate3DZ(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
 	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
-
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
 // Translate2D returns a homogeneous (3x3 for 2D-space) Translation matrix that moves a point by Tx units in the x-direction and Ty units in the y-direction
 //
-//    [[1, 0, Tx]]
-//    [[0, 1, Ty]]
-//    [[0, 0, 1 ]]
+//	[[1, 0, Tx]]
+//	[[0, 1, Ty]]
+//	[[0, 0, 1 ]]
 func Translate2D(Tx, Ty float64) Mat3 {
 	return Mat3{1, 0, 0, 0, 1, 0, float64(Tx), float64(Ty), 1}
 }
@@ -68,10 +68,10 @@ func Translate2D(Tx, Ty float64) Mat3 {
 // Translate3D returns a homogeneous (4x4 for 3D-space) Translation matrix that moves a point by Tx units in the x-direction, Ty units in the y-direction,
 // and Tz units in the z-direction
 //
-//    [[1, 0, 0, Tx]]
-//    [[0, 1, 0, Ty]]
-//    [[0, 0, 1, Tz]]
-//    [[0, 0, 0, 1 ]]
+//	[[1, 0, 0, Tx]]
+//	[[0, 1, 0, Ty]]
+//	[[0, 0, 1, Tz]]
+//	[[0, 0, 0, 1 ]]
 func Translate3D(Tx, Ty, Tz float64) Mat4 {
 	return Mat4{1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, float64(Tx), float64(Ty), float64(Tz), 1}
 }
@@ -154,10 +154,10 @@ func ShearZ3D(shearX, shearY float64) Mat4 {
 //
 // Where c is cos(angle) and s is sin(angle), and x, y, and z are the first, second, and third elements of the axis vector (respectively):
 //
-//    [[ x^2(1-c)+c, xy(1-c)-zs, xz(1-c)+ys, 0 ]]
-//    [[ xy(1-c)+zs, y^2(1-c)+c, yz(1-c)-xs, 0 ]]
-//    [[ xz(1-c)-ys, yz(1-c)+xs, z^2(1-c)+c, 0 ]]
-//    [[ 0         , 0         , 0         , 1 ]]
+//	[[ x^2(1-c)+c, xy(1-c)-zs, xz(1-c)+ys, 0 ]]
+//	[[ xy(1-c)+zs, y^2(1-c)+c, yz(1-c)-xs, 0 ]]
+//	[[ xz(1-c)-ys, yz(1-c)+xs, z^2(1-c)+c, 0 ]]
+//	[[ 0         , 0         , 0         , 1 ]]
 func HomogRotate3D(angle float64, axis Vec3) Mat4 {
 	x, y, z := axis[0], axis[1], axis[2]
 	s, c := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
@@ -196,9 +196,10 @@ func Mat4Normal(m Mat4) Mat3 {
 // This is similar to saying you're transforming and projecting a point.
 //
 // This is effectively equivalent to the GLSL code
-//     vec4 r = (m * vec4(v,1.));
-//     r = r/r.w;
-//     vec3 newV = r.xyz;
+//
+//	vec4 r = (m * vec4(v,1.));
+//	r = r/r.w;
+//	vec3 newV = r.xyz;
 func TransformCoordinate(v Vec3, m Mat4) Vec3 {
 	t := v.Vec4(1)
 	t = m.Mul4x1(t)
@@ -215,8 +216,9 @@ func TransformCoordinate(v Vec3, m Mat4) Vec3 {
 // but translating a direction or normal is meaningless.
 //
 // This is effectively equivalent to the GLSL code
-//    vec4 r = (m * vec4(v,0.));
-//    vec3 newV = r.xyz
+//
+//	vec4 r = (m * vec4(v,0.));
+//	vec3 newV = r.xyz
 func TransformNormal(v Vec3, m Mat4) Vec3 {
 	t := v.Vec4(0)
 	t = m.Mul4x1(t)

--- a/mgl64/transform.go
+++ b/mgl64/transform.go
@@ -13,7 +13,8 @@ import "math"
 // see HomogRotate2D
 func Rotate2D(angle float64) Mat2 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 	return Mat2{cos, sin, -sin, cos}
 }
 
@@ -26,7 +27,8 @@ func Rotate2D(angle float64) Mat2 {
 //	[0 s c ]
 func Rotate3DX(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 	return Mat3{1, 0, 0, 0, cos, sin, 0, -sin, cos}
 }
 
@@ -39,7 +41,8 @@ func Rotate3DX(angle float64) Mat3 {
 //	[s 0 c ]
 func Rotate3DY(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 	return Mat3{cos, 0, -sin, 0, 1, 0, sin, 0, cos}
 }
 
@@ -52,7 +55,8 @@ func Rotate3DY(angle float64) Mat3 {
 //	[0 0 1 ]
 func Rotate3DZ(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
@@ -79,14 +83,16 @@ func Translate3D(Tx, Ty, Tz float64) Mat4 {
 // HomogRotate2D is the same as Rotate2D, except homogeneous (3x3 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate2D(angle float64) Mat3 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 	return Mat3{cos, sin, 0, -sin, cos, 0, 0, 0, 1}
 }
 
 // HomogRotate3DX is the same as Rotate3DX, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DX(angle float64) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 
 	return Mat4{1, 0, 0, 0, 0, cos, sin, 0, 0, -sin, cos, 0, 0, 0, 0, 1}
 }
@@ -94,14 +100,16 @@ func HomogRotate3DX(angle float64) Mat4 {
 // HomogRotate3DY is the same as Rotate3DY, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DY(angle float64) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 	return Mat4{cos, 0, -sin, 0, 0, 1, 0, 0, sin, 0, cos, 0, 0, 0, 0, 1}
 }
 
 // HomogRotate3DZ is the same as Rotate3DZ, except homogeneous (4x4 with the extra row/col being all zeroes with a one in the bottom right)
 func HomogRotate3DZ(angle float64) Mat4 {
 	//angle = (angle * math.Pi) / 180.0
-	sin, cos := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	sin, cos := float64(sn), float64(cs)
 	return Mat4{cos, sin, 0, 0, -sin, cos, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1}
 }
 
@@ -160,7 +168,8 @@ func ShearZ3D(shearX, shearY float64) Mat4 {
 //	[[ 0         , 0         , 0         , 1 ]]
 func HomogRotate3D(angle float64, axis Vec3) Mat4 {
 	x, y, z := axis[0], axis[1], axis[2]
-	s, c := float64(math.Sin(float64(angle))), float64(math.Cos(float64(angle)))
+	sn, cs := math.Sincos(float64(angle))
+	s, c := float64(sn), float64(cs)
 	k := 1 - c
 
 	return Mat4{x*x*k + c, x*y*k + z*s, x*z*k - y*s, 0, x*y*k - z*s, y*y*k + c, y*z*k + x*s, 0, x*z*k + y*s, y*z*k - x*s, z*z*k + c, 0, 0, 0, 0, 1}


### PR DESCRIPTION
Accidentally noticed that many functions were using separate Sin and Cos calls which end up slower than a single call to Sincos.