### PR TITLE
Drop golang.org/x/image dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,3 @@
 module github.com/go-gl/mathgl
 
 go 1.11
-
-require golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,0 @@
-golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f h1:FO4MZ3N56GnxbqxGKqh+YTzUWQ2sDwtFQEZgLOxh9Jc=
-golang.org/x/image v0.0.0-20190321063152-3fc05d484e9f/go.mod h1:kZ7UVZpmo3dzQBMxlp+ypCbDeSB+sBbTgSJuh5dn5js=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/mgl32/matrix.go
+++ b/mgl32/matrix.go
@@ -10,19 +10,18 @@ package mgl32
 import (
 	"bytes"
 	"fmt"
-	"golang.org/x/image/math/f32"
 	"text/tabwriter"
 )
 
-type Mat2 [4]float32
-type Mat2x3 [6]float32
-type Mat2x4 [8]float32
-type Mat3x2 [6]float32
-type Mat3 f32.Mat3
-type Mat3x4 [12]float32
-type Mat4x2 [8]float32
-type Mat4x3 [12]float32
-type Mat4 f32.Mat4
+type Mat2 [2 * 2]float32
+type Mat2x3 [2 * 3]float32
+type Mat2x4 [2 * 4]float32
+type Mat3x2 [3 * 2]float32
+type Mat3 [3 * 3]float32
+type Mat3x4 [3 * 4]float32
+type Mat4x2 [4 * 2]float32
+type Mat4x3 [4 * 3]float32
+type Mat4 [4 * 4]float32
 
 func (m Mat2) Mat3() Mat3 {
 	col0, col1 := m.Cols()

--- a/mgl32/matrix.tmpl
+++ b/mgl32/matrix.tmpl
@@ -10,19 +10,18 @@ package mgl32
 import (
 	"bytes"
 	"fmt"
-	"golang.org/x/image/math/f32"
 	"text/tabwriter"
 )
 
-type Mat2 [4]float32
-type Mat2x3 [6]float32
-type Mat2x4 [8]float32
-type Mat3x2 [6]float32
-type Mat3 f32.Mat3
-type Mat3x4 [12]float32
-type Mat4x2 [8]float32
-type Mat4x3 [12]float32
-type Mat4 f32.Mat4
+type Mat2   [2*2]float32
+type Mat2x3 [2*3]float32
+type Mat2x4 [2*4]float32
+type Mat3x2 [3*2]float32
+type Mat3   [3*3]float32
+type Mat3x4 [3*4]float32
+type Mat4x2 [4*2]float32
+type Mat4x3 [4*3]float32
+type Mat4   [4*4]float32
 
 func (m Mat2) Mat3() Mat3 {
 	col0, col1 := m.Cols()

--- a/mgl32/vector.go
+++ b/mgl32/vector.go
@@ -8,13 +8,12 @@
 package mgl32
 
 import (
-	"golang.org/x/image/math/f32"
 	"math"
 )
 
-type Vec2 f32.Vec2
-type Vec3 f32.Vec3
-type Vec4 f32.Vec4
+type Vec2 [2]float32
+type Vec3 [3]float32
+type Vec4 [4]float32
 
 // Vec3 constructs a 3-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec3(z float32) Vec3 {

--- a/mgl32/vector.tmpl
+++ b/mgl32/vector.tmpl
@@ -8,13 +8,12 @@
 package mgl32
 
 import (
-	"golang.org/x/image/math/f32"
 	"math"
 )
 
-type Vec2 f32.Vec2
-type Vec3 f32.Vec3
-type Vec4 f32.Vec4
+type Vec2 [2]float32
+type Vec3 [3]float32
+type Vec4 [4]float32
 
 // Vec3 constructs a 3-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec3(z float32) Vec3 {

--- a/mgl64/matrix.go
+++ b/mgl64/matrix.go
@@ -13,19 +13,17 @@ import (
 	"bytes"
 	"fmt"
 	"text/tabwriter"
-
-	"golang.org/x/image/math/f64"
 )
 
-type Mat2 [4]float64
-type Mat2x3 [6]float64
-type Mat2x4 [8]float64
-type Mat3x2 [6]float64
-type Mat3 f64.Mat3
-type Mat3x4 [12]float64
-type Mat4x2 [8]float64
-type Mat4x3 [12]float64
-type Mat4 f64.Mat4
+type Mat2 [2 * 2]float64
+type Mat2x3 [2 * 3]float64
+type Mat2x4 [2 * 4]float64
+type Mat3x2 [3 * 2]float64
+type Mat3 [3 * 3]float64
+type Mat3x4 [3 * 4]float64
+type Mat4x2 [4 * 2]float64
+type Mat4x3 [4 * 3]float64
+type Mat4 [4 * 4]float64
 
 func (m Mat2) Mat3() Mat3 {
 	col0, col1 := m.Cols()

--- a/mgl64/vector.go
+++ b/mgl64/vector.go
@@ -11,13 +11,11 @@ package mgl64
 
 import (
 	"math"
-
-	"golang.org/x/image/math/f64"
 )
 
-type Vec2 f64.Vec2
-type Vec3 f64.Vec3
-type Vec4 f64.Vec4
+type Vec2 [2]float64
+type Vec3 [3]float64
+type Vec4 [4]float64
 
 // Vec3 constructs a 3-dimensional vector by appending the given coordinates.
 func (v Vec2) Vec3(z float64) Vec3 {


### PR DESCRIPTION
This uses https://github.com/go-gl/mathgl/pull/95 as the base. So merge the other one before this.

There doesn't seem to be any real benfit from depending on golang.org/x/image, so drop it.