### PR TITLE
remove unnecessary call to Normalize().

### DIFF
--- a/mgl32/project.go
+++ b/mgl32/project.go
@@ -47,7 +47,7 @@ func LookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ float32) 
 // space.
 func LookAtV(eye, center, up Vec3) Mat4 {
 	f := center.Sub(eye).Normalize()
-	s := f.Cross(up.Normalize()).Normalize()
+	s := f.Cross(up).Normalize()
 	u := s.Cross(f)
 
 	M := Mat4{

--- a/mgl64/project.go
+++ b/mgl64/project.go
@@ -49,7 +49,7 @@ func LookAt(eyeX, eyeY, eyeZ, centerX, centerY, centerZ, upX, upY, upZ float64) 
 // space.
 func LookAtV(eye, center, up Vec3) Mat4 {
 	f := center.Sub(eye).Normalize()
-	s := f.Cross(up.Normalize()).Normalize()
+	s := f.Cross(up).Normalize()
 	u := s.Cross(f)
 
 	M := Mat4{


### PR DESCRIPTION
Normalizing vectors before or after the operation does not matter, but both is not necessary.